### PR TITLE
feat: add SSE/WebSocket push notifier switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- DOC_META_START -->
 > [!NOTE]
 > - **Created At**: `2026-02-09 00:33:02`
-> - **Updated At**: `2026-02-17 22:17:25`
+> - **Updated At**: `2026-02-18 23:00:33`
 <!-- DOC_META_END -->
 
 <!-- DOC_TOC_START -->
@@ -59,6 +59,11 @@ make test-k6
 
 - API 스크립트 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/latest.md`
 - k6 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/k6/latest/k6-latest.md`
+- 실시간 푸시 모드 스위치: `APP_PUSH_MODE=sse|websocket` (기본값 `sse`)
+- WebSocket STOMP 엔드포인트: `/ws` (`/topic/waiting-queue/{concertId}/{userId}`, `/topic/reservations/{seatId}/{userId}`)
+- WebSocket 구독 등록 API:
+  - `POST /api/push/websocket/waiting-queue/subscriptions`
+  - `POST /api/push/websocket/reservations/subscriptions`
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/scripts/api/v13-websocket-switching.sh
+++ b/scripts/api/v13-websocket-switching.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_HOST="${API_HOST:-http://127.0.0.1:8080}"
+USER_API="${API_HOST}/api/users"
+CONCERT_SETUP_API="${API_HOST}/api/concerts/setup"
+CONCERT_API="${API_HOST}/api/concerts"
+WS_PUSH_API="${API_HOST}/api/push/websocket"
+TS="$(date +%s)"
+USER_NAME="ws-user-${TS}"
+CONTENT_TYPE="Content-Type: application/json"
+
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+USER_ID=""
+CONCERT_ID=""
+
+cleanup() {
+    if [[ -n "${USER_ID}" ]]; then
+        curl -s -X DELETE "${USER_API}/${USER_ID}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${CONCERT_ID}" ]]; then
+        curl -s -X DELETE "${CONCERT_API}/cleanup/${CONCERT_ID}" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+echo -e "${BLUE}>>>> [v13 Test] WebSocket subscription API 검증 시작...${NC}"
+
+echo -ne "${YELLOW}[Step 1] 테스트 유저 생성... ${NC}"
+USER_RESPONSE="$(curl -s -X POST "${USER_API}" -H "${CONTENT_TYPE}" -d "{\"username\":\"${USER_NAME}\",\"tier\":\"BASIC\"}")"
+USER_ID="$(echo "${USER_RESPONSE}" | grep -oP '"id":\s*\K\d+' || true)"
+if [[ -z "${USER_ID}" ]]; then
+    echo -e "${RED}실패! 유저 생성 실패: ${USER_RESPONSE}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (userId=${USER_ID})${NC}"
+
+echo -ne "${YELLOW}[Step 2] 테스트 공연 생성... ${NC}"
+SETUP_RESPONSE="$(curl -s -X POST "${CONCERT_SETUP_API}" -H "${CONTENT_TYPE}" -d "{
+  \"title\": \"WS_TEST_${TS}\",
+  \"artistName\": \"WS_ARTIST_${TS}\",
+  \"agencyName\": \"WS_AGENCY_${TS}\",
+  \"concertDate\": \"2026-06-01T18:00:00\",
+  \"seatCount\": 30
+}")"
+CONCERT_ID="$(echo "${SETUP_RESPONSE}" | grep -oP 'ConcertID=\K\d+' || true)"
+OPTION_ID="$(echo "${SETUP_RESPONSE}" | grep -oP 'OptionID=\K\d+' || true)"
+if [[ -z "${CONCERT_ID}" || -z "${OPTION_ID}" ]]; then
+    echo -e "${RED}실패! 공연 생성 실패: ${SETUP_RESPONSE}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (concertId=${CONCERT_ID}, optionId=${OPTION_ID})${NC}"
+
+SEAT_ID="$(curl -s "${CONCERT_API}/options/${OPTION_ID}/seats" | grep -oP '"id":\s*\K\d+' | head -n 1 || true)"
+if [[ -z "${SEAT_ID}" ]]; then
+    echo -e "${RED}실패! 좌석 조회 실패${NC}"
+    exit 1
+fi
+
+echo -ne "${YELLOW}[Step 3] WebSocket 대기열 구독 등록... ${NC}"
+QUEUE_SUBSCRIBE_RAW="$(curl -s -w '\n%{http_code}' -X POST "${WS_PUSH_API}/waiting-queue/subscriptions" \
+    -H "${CONTENT_TYPE}" \
+    -d "{\"userId\":${USER_ID},\"concertId\":${CONCERT_ID}}")"
+QUEUE_SUBSCRIBE_BODY="$(echo "${QUEUE_SUBSCRIBE_RAW}" | sed '$d')"
+QUEUE_SUBSCRIBE_CODE="$(echo "${QUEUE_SUBSCRIBE_RAW}" | tail -n 1)"
+EXPECTED_QUEUE_DEST="/topic/waiting-queue/${CONCERT_ID}/${USER_ID}"
+if [[ "${QUEUE_SUBSCRIBE_CODE}" != "200" || "${QUEUE_SUBSCRIBE_BODY}" != *"${EXPECTED_QUEUE_DEST}"* ]]; then
+    echo -e "${RED}실패! 대기열 구독 등록 실패: ${QUEUE_SUBSCRIBE_BODY} (${QUEUE_SUBSCRIBE_CODE})${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공${NC}"
+
+echo -ne "${YELLOW}[Step 4] WebSocket 대기열 구독 해제... ${NC}"
+QUEUE_UNSUBSCRIBE_CODE="$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "${WS_PUSH_API}/waiting-queue/subscriptions?userId=${USER_ID}&concertId=${CONCERT_ID}")"
+if [[ "${QUEUE_UNSUBSCRIBE_CODE}" != "204" ]]; then
+    echo -e "${RED}실패! 대기열 구독 해제 실패: ${QUEUE_UNSUBSCRIBE_CODE}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공${NC}"
+
+echo -ne "${YELLOW}[Step 5] WebSocket 예약 구독 등록... ${NC}"
+RESERVATION_SUBSCRIBE_RAW="$(curl -s -w '\n%{http_code}' -X POST "${WS_PUSH_API}/reservations/subscriptions" \
+    -H "${CONTENT_TYPE}" \
+    -d "{\"userId\":${USER_ID},\"seatId\":${SEAT_ID}}")"
+RESERVATION_SUBSCRIBE_BODY="$(echo "${RESERVATION_SUBSCRIBE_RAW}" | sed '$d')"
+RESERVATION_SUBSCRIBE_CODE="$(echo "${RESERVATION_SUBSCRIBE_RAW}" | tail -n 1)"
+EXPECTED_RES_DEST="/topic/reservations/${SEAT_ID}/${USER_ID}"
+if [[ "${RESERVATION_SUBSCRIBE_CODE}" != "200" || "${RESERVATION_SUBSCRIBE_BODY}" != *"${EXPECTED_RES_DEST}"* ]]; then
+    echo -e "${RED}실패! 예약 구독 등록 실패: ${RESERVATION_SUBSCRIBE_BODY} (${RESERVATION_SUBSCRIBE_CODE})${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공${NC}"
+
+echo -ne "${YELLOW}[Step 6] WebSocket 예약 구독 해제... ${NC}"
+RESERVATION_UNSUBSCRIBE_CODE="$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "${WS_PUSH_API}/reservations/subscriptions?userId=${USER_ID}&seatId=${SEAT_ID}")"
+if [[ "${RESERVATION_UNSUBSCRIBE_CODE}" != "204" ]]; then
+    echo -e "${RED}실패! 예약 구독 해제 실패: ${RESERVATION_UNSUBSCRIBE_CODE}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공${NC}"
+
+echo -e "${GREEN}>>>> [v13 Test] 검증 종료 (PASS).${NC}"

--- a/scripts/http/reservation.http
+++ b/scripts/http/reservation.http
@@ -118,7 +118,16 @@ GET {{host}}/api/reservations/v4/status?userId={{ownerUserId}}&seatId={{seatId4}
 GET {{host}}/api/reservations/v5/subscribe?userId={{ownerUserId}}&seatId={{seatId4}}
 Accept: text/event-stream
 
-### 12) Step 9 - 좌석 홀드 생성 (HOLD)
+### 12) 실시간 알림 구독 등록 (WebSocket, mode=websocket)
+POST {{host}}/api/push/websocket/reservations/subscriptions
+Content-Type: application/json
+
+{
+  "userId": {{ownerUserId}},
+  "seatId": {{seatId4}}
+}
+
+### 13) Step 9 - 좌석 홀드 생성 (HOLD)
 POST {{host}}/api/reservations/v6/holds
 Content-Type: application/json
 
@@ -136,7 +145,7 @@ client.test("v6 hold created", function() {
 client.global.set("reservationId", String(response.body.id));
 %}
 
-### 13) Step 9 - 결제 진행 전이 (HOLD -> PAYING)
+### 14) Step 9 - 결제 진행 전이 (HOLD -> PAYING)
 POST {{host}}/api/reservations/v6/{{reservationId}}/paying
 Content-Type: application/json
 
@@ -144,7 +153,7 @@ Content-Type: application/json
   "userId": {{vipUserId}}
 }
 
-### 14) Step 9 - 결제 확정 전이 (PAYING -> CONFIRMED)
+### 15) Step 9 - 결제 확정 전이 (PAYING -> CONFIRMED)
 POST {{host}}/api/reservations/v6/{{reservationId}}/confirm
 Content-Type: application/json
 
@@ -152,10 +161,10 @@ Content-Type: application/json
   "userId": {{vipUserId}}
 }
 
-### 15) Step 9 - 상태 조회
+### 16) Step 9 - 상태 조회
 GET {{host}}/api/reservations/v6/{{reservationId}}?userId={{vipUserId}}
 
-### 16) Step 10 - 예약 취소 (CONFIRMED -> CANCELLED)
+### 17) Step 10 - 예약 취소 (CONFIRMED -> CANCELLED)
 POST {{host}}/api/reservations/v6/{{reservationId}}/cancel
 Content-Type: application/json
 
@@ -163,7 +172,7 @@ Content-Type: application/json
   "userId": {{vipUserId}}
 }
 
-### 17) Step 10 - 환불 완료 (CANCELLED -> REFUNDED)
+### 18) Step 10 - 환불 완료 (CANCELLED -> REFUNDED)
 POST {{host}}/api/reservations/v6/{{reservationId}}/refund
 Content-Type: application/json
 
@@ -171,10 +180,10 @@ Content-Type: application/json
   "userId": {{vipUserId}}
 }
 
-### 18) Step 10 - 최종 상태 조회
+### 19) Step 10 - 최종 상태 조회
 GET {{host}}/api/reservations/v6/{{reservationId}}?userId={{vipUserId}}
 
-### 19) Step 11 - 판매 정책 생성/수정
+### 20) Step 11 - 판매 정책 생성/수정
 PUT {{host}}/api/concerts/{{concertId}}/sales-policy
 Content-Type: application/json
 
@@ -186,10 +195,10 @@ Content-Type: application/json
   "maxReservationsPerUser": 1
 }
 
-### 20) Step 11 - 판매 정책 조회
+### 21) Step 11 - 판매 정책 조회
 GET {{host}}/api/concerts/{{concertId}}/sales-policy
 
-### 21) Step 11 - 정책 적용 HOLD 1건 (성공 예상)
+### 22) Step 11 - 정책 적용 HOLD 1건 (성공 예상)
 POST {{host}}/api/reservations/v6/holds
 Content-Type: application/json
 
@@ -205,7 +214,7 @@ if (response.status === 201 && response.body && response.body.id) {
 }
 %}
 
-### 22) Step 11 - 정책 적용 HOLD 2건 (limit=1, 실패 예상)
+### 23) Step 11 - 정책 적용 HOLD 2건 (limit=1, 실패 예상)
 POST {{host}}/api/reservations/v6/holds
 Content-Type: application/json
 
@@ -216,17 +225,20 @@ Content-Type: application/json
   "deviceFingerprint": "policy-device-{{ts}}"
 }
 
-### 23) Step 12 - 감사 로그 조회
+### 24) Step 12 - 감사 로그 조회
 GET {{host}}/api/reservations/v6/audit/abuse?result=BLOCKED&limit=20
 
-### 24) 정리 - 유저 예약 목록 조회
+### 25) WebSocket 예약 구독 해제
+DELETE {{host}}/api/push/websocket/reservations/subscriptions?userId={{ownerUserId}}&seatId={{seatId4}}
+
+### 26) 정리 - 유저 예약 목록 조회
 GET {{host}}/api/reservations/users/{{vipUserId}}
 
-### 25) 정리 - 테스트 유저 삭제 (owner)
+### 27) 정리 - 테스트 유저 삭제 (owner)
 DELETE {{host}}/api/users/{{ownerUserId}}
 
-### 26) 정리 - 테스트 유저 삭제 (vip)
+### 28) 정리 - 테스트 유저 삭제 (vip)
 DELETE {{host}}/api/users/{{vipUserId}}
 
-### 27) 정리 - 테스트 공연 삭제
+### 29) 정리 - 테스트 공연 삭제
 DELETE {{host}}/api/concerts/cleanup/{{concertId}}

--- a/scripts/http/waiting-queue.http
+++ b/scripts/http/waiting-queue.http
@@ -52,8 +52,20 @@ GET {{host}}/api/v1/waiting-queue/status?userId={{waitingUserId}}&concertId={{wa
 GET {{host}}/api/v1/waiting-queue/subscribe?userId={{waitingUserId}}&concertId={{waitingConcertId}}
 Accept: text/event-stream
 
-### 6) 정리 - 테스트 유저 삭제
+### 6) WebSocket 순번 구독 등록 (Step 7, mode=websocket)
+POST {{host}}/api/push/websocket/waiting-queue/subscriptions
+Content-Type: application/json
+
+{
+  "userId": {{waitingUserId}},
+  "concertId": {{waitingConcertId}}
+}
+
+### 7) WebSocket 순번 구독 해제
+DELETE {{host}}/api/push/websocket/waiting-queue/subscriptions?userId={{waitingUserId}}&concertId={{waitingConcertId}}
+
+### 8) 정리 - 테스트 유저 삭제
 DELETE {{host}}/api/users/{{waitingUserId}}
 
-### 7) 정리 - 테스트 공연 삭제
+### 9) 정리 - 테스트 공연 삭제
 DELETE {{host}}/api/concerts/cleanup/{{waitingConcertId}}

--- a/src/main/java/com/ticketrush/api/controller/ReservationController.java
+++ b/src/main/java/com/ticketrush/api/controller/ReservationController.java
@@ -8,7 +8,7 @@ import com.ticketrush.domain.reservation.event.ReservationEvent;
 import com.ticketrush.domain.reservation.entity.AbuseAuditLog;
 import com.ticketrush.global.lock.RedissonLockFacade;
 import com.ticketrush.global.messaging.KafkaReservationProducer;
-import com.ticketrush.global.sse.SseEmitterManager;
+import com.ticketrush.global.sse.SsePushNotifier;
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.api.dto.ReservationResponse;
 import com.ticketrush.api.dto.reservation.AuthenticatedHoldRequest;
@@ -39,7 +39,7 @@ public class ReservationController {
     private final ReservationQueueService queueService;
     private final ReservationLifecycleService reservationLifecycleService;
     private final AbuseAuditService abuseAuditService;
-    private final SseEmitterManager sseManager;
+    private final SsePushNotifier ssePushNotifier;
 
     /**
      * [v1] 낙관적 락 버전
@@ -99,7 +99,7 @@ public class ReservationController {
     public SseEmitter subscribe(
             @RequestParam Long userId,
             @RequestParam Long seatId) {
-        return sseManager.subscribeReservation(userId, seatId);
+        return ssePushNotifier.subscribeReservation(userId, seatId);
     }
 
     /**

--- a/src/main/java/com/ticketrush/api/controller/WebSocketPushController.java
+++ b/src/main/java/com/ticketrush/api/controller/WebSocketPushController.java
@@ -1,0 +1,64 @@
+package com.ticketrush.api.controller;
+
+import com.ticketrush.api.dto.push.WebSocketQueueSubscriptionRequest;
+import com.ticketrush.api.dto.push.WebSocketReservationSubscriptionRequest;
+import com.ticketrush.global.push.WebSocketPushNotifier;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/push/websocket")
+@RequiredArgsConstructor
+public class WebSocketPushController {
+
+    private final WebSocketPushNotifier webSocketPushNotifier;
+
+    @PostMapping("/waiting-queue/subscriptions")
+    public ResponseEntity<Map<String, String>> subscribeWaitingQueue(
+            @Valid @RequestBody WebSocketQueueSubscriptionRequest request
+    ) {
+        String destination = webSocketPushNotifier.subscribeQueue(request.getUserId(), request.getConcertId());
+        return ResponseEntity.ok(Map.of(
+                "transport", "websocket",
+                "destination", destination
+        ));
+    }
+
+    @DeleteMapping("/waiting-queue/subscriptions")
+    public ResponseEntity<Void> unsubscribeWaitingQueue(
+            @RequestParam Long userId,
+            @RequestParam Long concertId
+    ) {
+        webSocketPushNotifier.unsubscribeQueue(userId, concertId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/reservations/subscriptions")
+    public ResponseEntity<Map<String, String>> subscribeReservation(
+            @Valid @RequestBody WebSocketReservationSubscriptionRequest request
+    ) {
+        String destination = webSocketPushNotifier.subscribeReservation(request.getUserId(), request.getSeatId());
+        return ResponseEntity.ok(Map.of(
+                "transport", "websocket",
+                "destination", destination
+        ));
+    }
+
+    @DeleteMapping("/reservations/subscriptions")
+    public ResponseEntity<Void> unsubscribeReservation(
+            @RequestParam Long userId,
+            @RequestParam Long seatId
+    ) {
+        webSocketPushNotifier.unsubscribeReservation(userId, seatId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/push/WebSocketQueueSubscriptionRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/push/WebSocketQueueSubscriptionRequest.java
@@ -1,0 +1,16 @@
+package com.ticketrush.api.dto.push;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebSocketQueueSubscriptionRequest {
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private Long concertId;
+}

--- a/src/main/java/com/ticketrush/api/dto/push/WebSocketReservationSubscriptionRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/push/WebSocketReservationSubscriptionRequest.java
@@ -1,0 +1,16 @@
+package com.ticketrush.api.dto.push;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebSocketReservationSubscriptionRequest {
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private Long seatId;
+}

--- a/src/main/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceImpl.java
+++ b/src/main/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceImpl.java
@@ -13,7 +13,7 @@ import com.ticketrush.domain.reservation.repository.ReservationRepository;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.global.config.ReservationProperties;
 import com.ticketrush.global.cache.ConcertReadCacheEvictor;
-import com.ticketrush.global.sse.SseEmitterManager;
+import com.ticketrush.global.push.PushNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,7 +37,7 @@ public class ReservationLifecycleServiceImpl implements ReservationLifecycleServ
     private final ReservationProperties reservationProperties;
     private final SalesPolicyService salesPolicyService;
     private final AbuseAuditService abuseAuditService;
-    private final SseEmitterManager sseEmitterManager;
+    private final PushNotifier pushNotifier;
     private final ConcertReadCacheEvictor concertReadCacheEvictor;
 
     @Transactional
@@ -157,7 +157,7 @@ public class ReservationLifecycleServiceImpl implements ReservationLifecycleServ
                     .activeTtlSeconds(activeTtlSeconds)
                     .timestamp(Instant.now().toString())
                     .build();
-            sseEmitterManager.sendQueueActivated(activatedUserId, concertId, payload);
+            pushNotifier.sendQueueActivated(activatedUserId, concertId, payload);
         }
     }
 }

--- a/src/main/java/com/ticketrush/global/config/PushNotifierConfig.java
+++ b/src/main/java/com/ticketrush/global/config/PushNotifierConfig.java
@@ -1,0 +1,31 @@
+package com.ticketrush.global.config;
+
+import com.ticketrush.global.push.PushNotifier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Slf4j
+@Configuration
+@EnableConfigurationProperties(PushProperties.class)
+public class PushNotifierConfig {
+
+    @Bean
+    @Primary
+    public PushNotifier pushNotifier(
+            PushProperties properties,
+            @Qualifier("ssePushNotifier") PushNotifier ssePushNotifier,
+            @Qualifier("webSocketPushNotifier") PushNotifier webSocketPushNotifier
+    ) {
+        if (properties.getMode() == PushProperties.Mode.WEBSOCKET) {
+            log.info("Push notifier mode: WEBSOCKET");
+            return webSocketPushNotifier;
+        }
+
+        log.info("Push notifier mode: SSE");
+        return ssePushNotifier;
+    }
+}

--- a/src/main/java/com/ticketrush/global/config/PushProperties.java
+++ b/src/main/java/com/ticketrush/global/config/PushProperties.java
@@ -1,0 +1,18 @@
+package com.ticketrush.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.push")
+public class PushProperties {
+
+    private Mode mode = Mode.SSE;
+
+    public enum Mode {
+        SSE,
+        WEBSOCKET
+    }
+}

--- a/src/main/java/com/ticketrush/global/config/WebSocketConfig.java
+++ b/src/main/java/com/ticketrush/global/config/WebSocketConfig.java
@@ -1,0 +1,40 @@
+package com.ticketrush.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final List<String> normalizedAllowedOrigins;
+
+    public WebSocketConfig(
+            @Value("${app.frontend.allowed-origins:http://localhost:8080,http://127.0.0.1:8080}")
+            List<String> allowedOrigins
+    ) {
+        this.normalizedAllowedOrigins = allowedOrigins.stream()
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toList();
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns(normalizedAllowedOrigins.toArray(new String[0]));
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/ticketrush/global/messaging/KafkaReservationConsumer.java
+++ b/src/main/java/com/ticketrush/global/messaging/KafkaReservationConsumer.java
@@ -4,6 +4,7 @@ import com.ticketrush.domain.reservation.event.ReservationEvent;
 import com.ticketrush.domain.reservation.service.ReservationQueueService;
 import com.ticketrush.domain.reservation.service.ReservationService;
 import com.ticketrush.api.dto.ReservationRequest;
+import com.ticketrush.global.push.PushNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -16,7 +17,7 @@ public class KafkaReservationConsumer {
 
     private final ReservationService reservationService;
     private final ReservationQueueService queueService;
-    private final com.ticketrush.global.sse.SseEmitterManager sseManager;
+    private final PushNotifier pushNotifier;
 
     @KafkaListener(topics = "${app.kafka.topic.reservation}", groupId = "${spring.kafka.consumer.group-id:ticket-group}")
     public void consume(ReservationEvent event) {
@@ -36,7 +37,7 @@ public class KafkaReservationConsumer {
             }
 
             queueService.setStatus(event.getUserId(), event.getSeatId(), "SUCCESS");
-            sseManager.sendReservationStatus(event.getUserId(), event.getSeatId(), "SUCCESS");
+            pushNotifier.sendReservationStatus(event.getUserId(), event.getSeatId(), "SUCCESS");
             log.info("Reservation SUCCESS - UserId: {}, SeatId: {}", event.getUserId(), event.getSeatId());
 
         } catch (Exception e) {
@@ -53,7 +54,7 @@ public class KafkaReservationConsumer {
             }
             
             queueService.setStatus(event.getUserId(), event.getSeatId(), status);
-            sseManager.sendReservationStatus(event.getUserId(), event.getSeatId(), status);
+            pushNotifier.sendReservationStatus(event.getUserId(), event.getSeatId(), status);
         }
     }
 }

--- a/src/main/java/com/ticketrush/global/push/PushNotifier.java
+++ b/src/main/java/com/ticketrush/global/push/PushNotifier.java
@@ -1,0 +1,16 @@
+package com.ticketrush.global.push;
+
+import java.util.Set;
+
+public interface PushNotifier {
+
+    void sendReservationStatus(Long userId, Long seatId, String status);
+
+    void sendQueueRankUpdate(Long userId, Long concertId, Object data);
+
+    void sendQueueActivated(Long userId, Long concertId, Object data);
+
+    void sendQueueHeartbeat();
+
+    Set<Long> getSubscribedQueueUsers(Long concertId);
+}

--- a/src/main/java/com/ticketrush/global/push/WebSocketPushNotifier.java
+++ b/src/main/java/com/ticketrush/global/push/WebSocketPushNotifier.java
@@ -1,0 +1,120 @@
+package com.ticketrush.global.push;
+
+import com.ticketrush.global.sse.SseEventNames;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component("webSocketPushNotifier")
+@RequiredArgsConstructor
+public class WebSocketPushNotifier implements PushNotifier {
+
+    private static final String WAITING_QUEUE_TOPIC_PREFIX = "/topic/waiting-queue";
+    private static final String RESERVATION_TOPIC_PREFIX = "/topic/reservations";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final Map<Long, Set<Long>> queueSubscribersByConcert = new ConcurrentHashMap<>();
+    private final Set<String> reservationSubscriptions = ConcurrentHashMap.newKeySet();
+
+    public String subscribeQueue(Long userId, Long concertId) {
+        queueSubscribersByConcert
+                .computeIfAbsent(concertId, ignored -> ConcurrentHashMap.newKeySet())
+                .add(userId);
+        return queueDestination(userId, concertId);
+    }
+
+    public void unsubscribeQueue(Long userId, Long concertId) {
+        Set<Long> users = queueSubscribersByConcert.get(concertId);
+        if (users == null) {
+            return;
+        }
+        users.remove(userId);
+        if (users.isEmpty()) {
+            queueSubscribersByConcert.remove(concertId, users);
+        }
+    }
+
+    public String subscribeReservation(Long userId, Long seatId) {
+        reservationSubscriptions.add(reservationKey(userId, seatId));
+        return reservationDestination(userId, seatId);
+    }
+
+    public void unsubscribeReservation(Long userId, Long seatId) {
+        reservationSubscriptions.remove(reservationKey(userId, seatId));
+    }
+
+    @Override
+    public void sendReservationStatus(Long userId, Long seatId, String status) {
+        messagingTemplate.convertAndSend(
+                reservationDestination(userId, seatId),
+                Map.of(
+                        "event", SseEventNames.RESERVATION_STATUS,
+                        "userId", userId,
+                        "seatId", seatId,
+                        "status", status,
+                        "timestamp", Instant.now().toString()
+                )
+        );
+    }
+
+    @Override
+    public void sendQueueRankUpdate(Long userId, Long concertId, Object data) {
+        sendQueueEvent(userId, concertId, SseEventNames.RANK_UPDATE, data);
+    }
+
+    @Override
+    public void sendQueueActivated(Long userId, Long concertId, Object data) {
+        sendQueueEvent(userId, concertId, SseEventNames.ACTIVE, data);
+    }
+
+    @Override
+    public void sendQueueHeartbeat() {
+        String timestamp = Instant.now().toString();
+        queueSubscribersByConcert.forEach((concertId, users) -> {
+            for (Long userId : users) {
+                sendQueueEvent(userId, concertId, SseEventNames.KEEPALIVE, Map.of("timestamp", timestamp));
+            }
+        });
+    }
+
+    @Override
+    public Set<Long> getSubscribedQueueUsers(Long concertId) {
+        Set<Long> users = queueSubscribersByConcert.get(concertId);
+        if (users == null) {
+            return Set.of();
+        }
+        return new HashSet<>(users);
+    }
+
+    private void sendQueueEvent(Long userId, Long concertId, String eventName, Object data) {
+        messagingTemplate.convertAndSend(
+                queueDestination(userId, concertId),
+                Map.of(
+                        "event", eventName,
+                        "userId", userId,
+                        "concertId", concertId,
+                        "data", data
+                )
+        );
+    }
+
+    private String queueDestination(Long userId, Long concertId) {
+        return WAITING_QUEUE_TOPIC_PREFIX + "/" + concertId + "/" + userId;
+    }
+
+    private String reservationDestination(Long userId, Long seatId) {
+        return RESERVATION_TOPIC_PREFIX + "/" + seatId + "/" + userId;
+    }
+
+    private String reservationKey(Long userId, Long seatId) {
+        return userId + ":" + seatId;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ app:
   reservation:
     hold-ttl-seconds: 300
     expire-check-delay-millis: 5000
+  push:
+    mode: ${APP_PUSH_MODE:sse}
   waiting-queue:
     queue-key-prefix: "waiting-queue:"
     active-key-prefix: "active-user:"

--- a/src/test/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceIntegrationTest.java
+++ b/src/test/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceIntegrationTest.java
@@ -28,7 +28,7 @@ import com.ticketrush.domain.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.cache.ConcertReadCacheEvictor;
 import com.ticketrush.global.config.AbuseGuardProperties;
 import com.ticketrush.global.config.ReservationProperties;
-import com.ticketrush.global.sse.SseEmitterManager;
+import com.ticketrush.global.push.PushNotifier;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -87,8 +87,8 @@ class ReservationLifecycleServiceIntegrationTest {
         }
 
         @Bean
-        SseEmitterManager sseEmitterManager() {
-            return mock(SseEmitterManager.class);
+        PushNotifier pushNotifier() {
+            return mock(PushNotifier.class);
         }
 
         @Bean
@@ -134,7 +134,7 @@ class ReservationLifecycleServiceIntegrationTest {
     private WaitingQueueService waitingQueueService;
 
     @jakarta.annotation.Resource
-    private SseEmitterManager sseEmitterManager;
+    private PushNotifier pushNotifier;
 
     @Test
     void holdToPayingToConfirmed_shouldReserveSeat() {
@@ -202,7 +202,7 @@ class ReservationLifecycleServiceIntegrationTest {
                 .isEqualTo(Seat.SeatStatus.AVAILABLE);
 
         verify(waitingQueueService).activateUsers(concertId, 1);
-        verify(sseEmitterManager).sendQueueActivated(eq(999L), eq(concertId), any());
+        verify(pushNotifier).sendQueueActivated(eq(999L), eq(concertId), any());
     }
 
     @Test

--- a/src/test/java/com/ticketrush/global/config/PushNotifierConfigTest.java
+++ b/src/test/java/com/ticketrush/global/config/PushNotifierConfigTest.java
@@ -1,0 +1,38 @@
+package com.ticketrush.global.config;
+
+import com.ticketrush.global.push.PushNotifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class PushNotifierConfigTest {
+
+    private final PushNotifierConfig config = new PushNotifierConfig();
+
+    @Test
+    void pushNotifier_shouldSelectSseWhenModeIsSse() {
+        PushProperties properties = new PushProperties();
+        properties.setMode(PushProperties.Mode.SSE);
+
+        PushNotifier ssePushNotifier = mock(PushNotifier.class);
+        PushNotifier webSocketPushNotifier = mock(PushNotifier.class);
+
+        PushNotifier selected = config.pushNotifier(properties, ssePushNotifier, webSocketPushNotifier);
+
+        assertThat(selected).isSameAs(ssePushNotifier);
+    }
+
+    @Test
+    void pushNotifier_shouldSelectWebSocketWhenModeIsWebsocket() {
+        PushProperties properties = new PushProperties();
+        properties.setMode(PushProperties.Mode.WEBSOCKET);
+
+        PushNotifier ssePushNotifier = mock(PushNotifier.class);
+        PushNotifier webSocketPushNotifier = mock(PushNotifier.class);
+
+        PushNotifier selected = config.pushNotifier(properties, ssePushNotifier, webSocketPushNotifier);
+
+        assertThat(selected).isSameAs(webSocketPushNotifier);
+    }
+}

--- a/src/test/java/com/ticketrush/global/push/WebSocketPushNotifierTest.java
+++ b/src/test/java/com/ticketrush/global/push/WebSocketPushNotifierTest.java
@@ -1,0 +1,47 @@
+package com.ticketrush.global.push;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class WebSocketPushNotifierTest {
+
+    @Test
+    void subscribeQueue_shouldTrackSubscribedUsersByConcert() {
+        SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate);
+
+        String destination = notifier.subscribeQueue(100L, 1L);
+
+        assertThat(destination).isEqualTo("/topic/waiting-queue/1/100");
+        assertThat(notifier.getSubscribedQueueUsers(1L)).isEqualTo(Set.of(100L));
+    }
+
+    @Test
+    void sendQueueActivated_shouldPublishToWaitingQueueTopic() {
+        SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate);
+
+        notifier.sendQueueActivated(100L, 1L, Map.of("status", "ACTIVE"));
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/waiting-queue/1/100"), anyMap());
+    }
+
+    @Test
+    void sendReservationStatus_shouldPublishToReservationTopic() {
+        SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate);
+
+        notifier.sendReservationStatus(100L, 500L, "SUCCESS");
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/reservations/500/100"), anyMap());
+    }
+}

--- a/src/test/java/com/ticketrush/global/scheduler/WaitingQueueSchedulerTest.java
+++ b/src/test/java/com/ticketrush/global/scheduler/WaitingQueueSchedulerTest.java
@@ -3,7 +3,7 @@ package com.ticketrush.global.scheduler;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
 import com.ticketrush.domain.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.config.WaitingQueueProperties;
-import com.ticketrush.global.sse.SseEmitterManager;
+import com.ticketrush.global.push.PushNotifier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,7 +29,7 @@ class WaitingQueueSchedulerTest {
     private WaitingQueueProperties properties;
 
     @Mock
-    private SseEmitterManager sseEmitterManager;
+    private PushNotifier pushNotifier;
 
     @InjectMocks
     private WaitingQueueScheduler waitingQueueScheduler;
@@ -41,7 +41,7 @@ class WaitingQueueSchedulerTest {
 
         when(waitingQueueService.activateUsers(1L, 10L)).thenReturn(List.of(101L));
         when(waitingQueueService.getActiveTtlSeconds(101L)).thenReturn(280L);
-        when(sseEmitterManager.getSubscribedQueueUsers(1L)).thenReturn(Set.of(101L, 102L));
+        when(pushNotifier.getSubscribedQueueUsers(1L)).thenReturn(Set.of(101L, 102L));
         when(waitingQueueService.getStatus(102L, 1L)).thenReturn(
                 WaitingQueueResponse.builder()
                         .userId(102L)
@@ -53,14 +53,14 @@ class WaitingQueueSchedulerTest {
 
         waitingQueueScheduler.activateWaitingUsers();
 
-        verify(sseEmitterManager).sendQueueActivated(eq(101L), eq(1L), any());
-        verify(sseEmitterManager).sendQueueRankUpdate(eq(102L), eq(1L), any());
+        verify(pushNotifier).sendQueueActivated(eq(101L), eq(1L), any());
+        verify(pushNotifier).sendQueueRankUpdate(eq(102L), eq(1L), any());
         verify(waitingQueueService, never()).getStatus(101L, 1L);
     }
 
     @Test
-    void sendQueueHeartbeat_delegateToSseEmitterManager() {
+    void sendQueueHeartbeat_delegateToPushNotifier() {
         waitingQueueScheduler.sendQueueHeartbeat();
-        verify(sseEmitterManager).sendQueueHeartbeat();
+        verify(pushNotifier).sendQueueHeartbeat();
     }
 }

--- a/src/test/java/com/ticketrush/global/sse/SsePushNotifierTest.java
+++ b/src/test/java/com/ticketrush/global/sse/SsePushNotifierTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-class SseEmitterManagerTest {
+class SsePushNotifierTest {
 
     @Test
     void subscribeQueue_shouldReplaceEmitterOnReconnect() {
-        SseEmitterManager manager = new SseEmitterManager(waitingQueueProperties());
+        SsePushNotifier manager = new SsePushNotifier(waitingQueueProperties());
 
         manager.subscribeQueue(100L, 1L);
         manager.subscribeQueue(100L, 1L); // reconnect
@@ -20,7 +20,7 @@ class SseEmitterManagerTest {
 
     @Test
     void getSubscribedQueueUsers_shouldFilterByConcertId() {
-        SseEmitterManager manager = new SseEmitterManager(waitingQueueProperties());
+        SsePushNotifier manager = new SsePushNotifier(waitingQueueProperties());
 
         manager.subscribeQueue(100L, 1L);
         manager.subscribeQueue(101L, 1L);
@@ -32,7 +32,7 @@ class SseEmitterManagerTest {
 
     @Test
     void sendQueueHeartbeat_shouldNotThrow() {
-        SseEmitterManager manager = new SseEmitterManager(waitingQueueProperties());
+        SsePushNotifier manager = new SsePushNotifier(waitingQueueProperties());
         manager.subscribeQueue(100L, 1L);
 
         assertThatCode(manager::sendQueueHeartbeat).doesNotThrowAnyException();


### PR DESCRIPTION
## Related Issue
- Closes #3

## Summary
- Introduce push abstraction with transport switching: `app.push.mode=sse|websocket`
- Keep existing SSE subscribe APIs (`/api/reservations/v5/subscribe`, `/api/v1/waiting-queue/subscribe`)
- Add WebSocket(STOMP) transport and subscription APIs
- Route scheduler/consumer/lifecycle push calls through shared `PushNotifier`

## Main Changes
- `PushNotifier` interface + selector config (`PushNotifierConfig`, `PushProperties`)
- SSE impl rename: `SseEmitterManager` -> `SsePushNotifier`
- WebSocket impl: `WebSocketPushNotifier`
- WebSocket broker config: endpoint `/ws`, topic prefix `/topic`
- New REST APIs:
  - `POST /api/push/websocket/waiting-queue/subscriptions`
  - `DELETE /api/push/websocket/waiting-queue/subscriptions`
  - `POST /api/push/websocket/reservations/subscriptions`
  - `DELETE /api/push/websocket/reservations/subscriptions`
- API script/example updates:
  - `scripts/api/v13-websocket-switching.sh`
  - `scripts/http/waiting-queue.http`
  - `scripts/http/reservation.http`

## Verification
- `./gradlew clean test` (pass)

## Checklist
- [x] Existing SSE APIs remain available
- [x] WebSocket push channel and subscribe APIs added
- [x] Transport mode switch via config (`APP_PUSH_MODE`)
- [x] Scheduler/consumer/lifecycle use notifier abstraction
- [x] Tests updated/added for mode selection + websocket notifier
