### PR TITLE
feat: add wallet ledger and reservation payment/refund integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- DOC_META_START -->
 > [!NOTE]
 > - **Created At**: `2026-02-09 00:33:02`
-> - **Updated At**: `2026-02-18 23:00:33`
+> - **Updated At**: `2026-02-18 23:52:32`
 <!-- DOC_META_END -->
 
 <!-- DOC_TOC_START -->
@@ -64,6 +64,13 @@ make test-k6
 - WebSocket 구독 등록 API:
   - `POST /api/push/websocket/waiting-queue/subscriptions`
   - `POST /api/push/websocket/reservations/subscriptions`
+- 지갑/결제 API:
+  - `GET /api/users/{userId}/wallet`
+  - `POST /api/users/{userId}/wallet/charges`
+  - `GET /api/users/{userId}/wallet/transactions`
+- 예약 결제 연동:
+  - `v6/v7 confirm`에서 기본 티켓 금액(`app.payment.default-ticket-price-amount`) 차감
+  - `v6/v7 refund`에서 해당 예약 결제 금액 환불
 
 ---
 

--- a/scripts/api/v14-wallet-payment-flow.sh
+++ b/scripts/api/v14-wallet-payment-flow.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_HOST="${API_HOST:-http://127.0.0.1:8080}"
+USER_API="${API_HOST}/api/users"
+CONCERT_API="${API_HOST}/api/concerts"
+RESERVATION_API="${API_HOST}/api/reservations"
+CONTENT_TYPE="Content-Type: application/json"
+TS="$(date +%s)"
+
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+USER_ID=""
+CONCERT_ID=""
+
+cleanup() {
+    if [[ -n "${USER_ID}" ]]; then
+        curl -s -X DELETE "${USER_API}/${USER_ID}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${CONCERT_ID}" ]]; then
+        curl -s -X DELETE "${CONCERT_API}/cleanup/${CONCERT_ID}" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+extract_json_number() {
+    local key="$1"
+    local body="$2"
+    echo "${body}" | grep -oP "\"${key}\":\\s*\\K-?[0-9]+" | head -n 1 || true
+}
+
+echo -e "${BLUE}>>>> [v14 Test] Wallet + Reservation Payment/Refund 흐름 검증 시작...${NC}"
+
+echo -ne "${YELLOW}[Step 1] 사용자 생성... ${NC}"
+USER_BODY="$(curl -s -X POST "${USER_API}" -H "${CONTENT_TYPE}" -d "{\"username\":\"wallet-user-${TS}\",\"tier\":\"BASIC\"}")"
+USER_ID="$(extract_json_number "id" "${USER_BODY}")"
+if [[ -z "${USER_ID}" ]]; then
+    echo -e "${RED}실패! 사용자 생성 실패: ${USER_BODY}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (userId=${USER_ID})${NC}"
+
+echo -ne "${YELLOW}[Step 2] 초기 잔액 확인... ${NC}"
+WALLET_BODY="$(curl -s "${USER_API}/${USER_ID}/wallet")"
+INITIAL_BALANCE="$(extract_json_number "walletBalanceAmount" "${WALLET_BODY}")"
+if [[ "${INITIAL_BALANCE}" != "200000" ]]; then
+    echo -e "${RED}실패! 초기 잔액이 기대값과 다름: ${WALLET_BODY}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (balance=${INITIAL_BALANCE})${NC}"
+
+echo -ne "${YELLOW}[Step 3] 지갑 충전(50,000)... ${NC}"
+CHARGE_KEY="wallet-charge-${USER_ID}-${TS}"
+CHARGE_RESPONSE="$(curl -s -X POST "${USER_API}/${USER_ID}/wallet/charges" -H "${CONTENT_TYPE}" -d "{
+  \"amount\": 50000,
+  \"idempotencyKey\": \"${CHARGE_KEY}\",
+  \"description\": \"SCRIPT_CHARGE\"
+}")"
+CHARGE_TYPE="$(echo "${CHARGE_RESPONSE}" | grep -oP '"type":"\K[^"]+' || true)"
+if [[ "${CHARGE_TYPE}" != "CHARGE" ]]; then
+    echo -e "${RED}실패! 충전 결과 오류: ${CHARGE_RESPONSE}${NC}"
+    exit 1
+fi
+WALLET_BODY="$(curl -s "${USER_API}/${USER_ID}/wallet")"
+BALANCE_AFTER_CHARGE="$(extract_json_number "walletBalanceAmount" "${WALLET_BODY}")"
+if [[ "${BALANCE_AFTER_CHARGE}" != "250000" ]]; then
+    echo -e "${RED}실패! 충전 후 잔액 오류: ${WALLET_BODY}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (balance=${BALANCE_AFTER_CHARGE})${NC}"
+
+echo -ne "${YELLOW}[Step 4] 공연/좌석 셋업... ${NC}"
+SETUP_BODY="$(curl -s -X POST "${CONCERT_API}/setup" -H "${CONTENT_TYPE}" -d "{
+  \"title\": \"WALLET_FLOW_${TS}\",
+  \"artistName\": \"WALLET_ARTIST_${TS}\",
+  \"agencyName\": \"WALLET_AGENCY_${TS}\",
+  \"concertDate\": \"2026-06-01T18:00:00\",
+  \"seatCount\": 10
+}")"
+CONCERT_ID="$(echo "${SETUP_BODY}" | grep -oP 'ConcertID=\K[0-9]+' || true)"
+OPTION_ID="$(echo "${SETUP_BODY}" | grep -oP 'OptionID=\K[0-9]+' || true)"
+if [[ -z "${CONCERT_ID}" || -z "${OPTION_ID}" ]]; then
+    echo -e "${RED}실패! 공연 셋업 실패: ${SETUP_BODY}${NC}"
+    exit 1
+fi
+SEAT_ID="$(curl -s "${CONCERT_API}/options/${OPTION_ID}/seats" | grep -oP '"id":\s*\K[0-9]+' | head -n 1 || true)"
+if [[ -z "${SEAT_ID}" ]]; then
+    echo -e "${RED}실패! 좌석 조회 실패${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (concertId=${CONCERT_ID}, seatId=${SEAT_ID})${NC}"
+
+echo -ne "${YELLOW}[Step 5] 예약 HOLD -> PAYING -> CONFIRMED... ${NC}"
+HOLD_BODY="$(curl -s -X POST "${RESERVATION_API}/v6/holds" -H "${CONTENT_TYPE}" -d "{
+  \"userId\": ${USER_ID},
+  \"seatId\": ${SEAT_ID},
+  \"requestFingerprint\": \"wallet-flow-hold-${TS}\",
+  \"deviceFingerprint\": \"wallet-flow-device-${TS}\"
+}")"
+RESERVATION_ID="$(extract_json_number "id" "${HOLD_BODY}")"
+if [[ -z "${RESERVATION_ID}" ]]; then
+    echo -e "${RED}실패! HOLD 생성 실패: ${HOLD_BODY}${NC}"
+    exit 1
+fi
+curl -s -X POST "${RESERVATION_API}/v6/${RESERVATION_ID}/paying" -H "${CONTENT_TYPE}" -d "{\"userId\": ${USER_ID}}" >/dev/null
+CONFIRM_BODY="$(curl -s -X POST "${RESERVATION_API}/v6/${RESERVATION_ID}/confirm" -H "${CONTENT_TYPE}" -d "{\"userId\": ${USER_ID}}")"
+CONFIRM_STATUS="$(echo "${CONFIRM_BODY}" | grep -oP '"status":"\K[^"]+' || true)"
+if [[ "${CONFIRM_STATUS}" != "CONFIRMED" ]]; then
+    echo -e "${RED}실패! CONFIRM 실패: ${CONFIRM_BODY}${NC}"
+    exit 1
+fi
+WALLET_BODY="$(curl -s "${USER_API}/${USER_ID}/wallet")"
+BALANCE_AFTER_CONFIRM="$(extract_json_number "walletBalanceAmount" "${WALLET_BODY}")"
+if [[ "${BALANCE_AFTER_CONFIRM}" != "150000" ]]; then
+    echo -e "${RED}실패! 결제 차감 잔액 오류: ${WALLET_BODY}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (balance=${BALANCE_AFTER_CONFIRM})${NC}"
+
+echo -ne "${YELLOW}[Step 6] CANCEL -> REFUND... ${NC}"
+curl -s -X POST "${RESERVATION_API}/v6/${RESERVATION_ID}/cancel" -H "${CONTENT_TYPE}" -d "{\"userId\": ${USER_ID}}" >/dev/null
+REFUND_BODY="$(curl -s -X POST "${RESERVATION_API}/v6/${RESERVATION_ID}/refund" -H "${CONTENT_TYPE}" -d "{\"userId\": ${USER_ID}}")"
+REFUND_STATUS="$(echo "${REFUND_BODY}" | grep -oP '"status":"\K[^"]+' || true)"
+if [[ "${REFUND_STATUS}" != "REFUNDED" ]]; then
+    echo -e "${RED}실패! REFUND 실패: ${REFUND_BODY}${NC}"
+    exit 1
+fi
+WALLET_BODY="$(curl -s "${USER_API}/${USER_ID}/wallet")"
+BALANCE_AFTER_REFUND="$(extract_json_number "walletBalanceAmount" "${WALLET_BODY}")"
+if [[ "${BALANCE_AFTER_REFUND}" != "250000" ]]; then
+    echo -e "${RED}실패! 환불 후 잔액 오류: ${WALLET_BODY}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공 (balance=${BALANCE_AFTER_REFUND})${NC}"
+
+echo -ne "${YELLOW}[Step 7] 거래 원장 조회... ${NC}"
+LEDGER_BODY="$(curl -s "${USER_API}/${USER_ID}/wallet/transactions?limit=20")"
+if [[ "${LEDGER_BODY}" != *"\"type\":\"PAYMENT\""* || "${LEDGER_BODY}" != *"\"type\":\"REFUND\""* ]]; then
+    echo -e "${RED}실패! 원장에 PAYMENT/REFUND가 보이지 않음: ${LEDGER_BODY}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}성공${NC}"
+
+echo -e "${GREEN}>>>> [v14 Test] 검증 종료 (PASS).${NC}"

--- a/scripts/http/user.http
+++ b/scripts/http/user.http
@@ -37,5 +37,21 @@ Content-Type: application/json
 ### 5) 수정 결과 재조회
 GET {{host}}/api/users/{{userId}}
 
-### 6) 유저 삭제
+### 6) 지갑 잔액 조회
+GET {{host}}/api/users/{{userId}}/wallet
+
+### 7) 지갑 충전
+POST {{host}}/api/users/{{userId}}/wallet/charges
+Content-Type: application/json
+
+{
+  "amount": 50000,
+  "idempotencyKey": "manual-charge-{{ts}}",
+  "description": "MANUAL_TEST_CHARGE"
+}
+
+### 8) 지갑 거래내역 조회
+GET {{host}}/api/users/{{userId}}/wallet/transactions?limit=20
+
+### 9) 유저 삭제
 DELETE {{host}}/api/users/{{userId}}

--- a/src/main/java/com/ticketrush/api/controller/WalletController.java
+++ b/src/main/java/com/ticketrush/api/controller/WalletController.java
@@ -1,0 +1,55 @@
+package com.ticketrush.api.controller;
+
+import com.ticketrush.api.dto.payment.PaymentTransactionResponse;
+import com.ticketrush.api.dto.payment.WalletBalanceResponse;
+import com.ticketrush.api.dto.payment.WalletChargeRequest;
+import com.ticketrush.domain.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users/{userId}/wallet")
+@RequiredArgsConstructor
+public class WalletController {
+
+    private final PaymentService paymentService;
+
+    @GetMapping
+    public ResponseEntity<WalletBalanceResponse> getWalletBalance(@PathVariable Long userId) {
+        return ResponseEntity.ok(new WalletBalanceResponse(userId, paymentService.getWalletBalance(userId)));
+    }
+
+    @PostMapping("/charges")
+    public ResponseEntity<PaymentTransactionResponse> chargeWallet(
+            @PathVariable Long userId,
+            @RequestBody WalletChargeRequest request
+    ) {
+        return ResponseEntity.ok(PaymentTransactionResponse.from(paymentService.chargeWallet(
+                userId,
+                request.getAmount(),
+                request.getIdempotencyKey(),
+                request.getDescription()
+        )));
+    }
+
+    @GetMapping("/transactions")
+    public ResponseEntity<List<PaymentTransactionResponse>> getTransactions(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "20") int limit
+    ) {
+        return ResponseEntity.ok(
+                paymentService.getTransactions(userId, limit).stream()
+                        .map(PaymentTransactionResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/UserResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/UserResponse.java
@@ -20,6 +20,7 @@ public class UserResponse {
     private String socialId;
     private String email;
     private String displayName;
+    private Long walletBalanceAmount;
 
     public static UserResponse from(User user) {
         return new UserResponse(
@@ -30,7 +31,8 @@ public class UserResponse {
                 user.getSocialProvider(),
                 user.getSocialId(),
                 user.getEmail(),
-                user.getDisplayName()
+                user.getDisplayName(),
+                user.getWalletBalanceAmountSafe()
         );
     }
 }

--- a/src/main/java/com/ticketrush/api/dto/payment/PaymentTransactionResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/payment/PaymentTransactionResponse.java
@@ -1,0 +1,41 @@
+package com.ticketrush.api.dto.payment;
+
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
+import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentTransactionResponse {
+    private Long id;
+    private Long userId;
+    private Long reservationId;
+    private PaymentTransactionType type;
+    private PaymentTransactionStatus status;
+    private Long amount;
+    private Long balanceAfterAmount;
+    private String idempotencyKey;
+    private String description;
+    private LocalDateTime createdAt;
+
+    public static PaymentTransactionResponse from(PaymentTransaction transaction) {
+        return new PaymentTransactionResponse(
+                transaction.getId(),
+                transaction.getUser().getId(),
+                transaction.getReservationId(),
+                transaction.getType(),
+                transaction.getStatus(),
+                transaction.getAmount(),
+                transaction.getBalanceAfterAmount(),
+                transaction.getIdempotencyKey(),
+                transaction.getDescription(),
+                transaction.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/payment/WalletBalanceResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/payment/WalletBalanceResponse.java
@@ -1,0 +1,13 @@
+package com.ticketrush.api.dto.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WalletBalanceResponse {
+    private Long userId;
+    private Long walletBalanceAmount;
+}

--- a/src/main/java/com/ticketrush/api/dto/payment/WalletChargeRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/payment/WalletChargeRequest.java
@@ -1,0 +1,14 @@
+package com.ticketrush.api.dto.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WalletChargeRequest {
+    private Long amount;
+    private String idempotencyKey;
+    private String description;
+}

--- a/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransaction.java
+++ b/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransaction.java
@@ -1,0 +1,156 @@
+package com.ticketrush.domain.payment.entity;
+
+import com.ticketrush.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "payment_transactions",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_transactions_idempotency_key", columnNames = {"idempotency_key"})
+        },
+        indexes = {
+                @Index(name = "idx_payment_transactions_user_created_at", columnList = "user_id,created_at"),
+                @Index(name = "idx_payment_transactions_reservation_type", columnList = "reservation_id,type")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "reservation_id")
+    private Long reservationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentTransactionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentTransactionStatus status;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "balance_after_amount", nullable = false)
+    private Long balanceAfterAmount;
+
+    @Column(name = "idempotency_key", nullable = false, length = 120)
+    private String idempotencyKey;
+
+    @Column(length = 255)
+    private String description;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static PaymentTransaction charge(
+            User user,
+            Long amount,
+            Long balanceAfterAmount,
+            String idempotencyKey,
+            String description
+    ) {
+        return new PaymentTransaction(
+                user,
+                null,
+                PaymentTransactionType.CHARGE,
+                PaymentTransactionStatus.SUCCESS,
+                amount,
+                balanceAfterAmount,
+                idempotencyKey,
+                description
+        );
+    }
+
+    public static PaymentTransaction payment(
+            User user,
+            Long reservationId,
+            Long amount,
+            Long balanceAfterAmount,
+            String idempotencyKey,
+            String description
+    ) {
+        return new PaymentTransaction(
+                user,
+                reservationId,
+                PaymentTransactionType.PAYMENT,
+                PaymentTransactionStatus.SUCCESS,
+                amount,
+                balanceAfterAmount,
+                idempotencyKey,
+                description
+        );
+    }
+
+    public static PaymentTransaction refund(
+            User user,
+            Long reservationId,
+            Long amount,
+            Long balanceAfterAmount,
+            String idempotencyKey,
+            String description
+    ) {
+        return new PaymentTransaction(
+                user,
+                reservationId,
+                PaymentTransactionType.REFUND,
+                PaymentTransactionStatus.SUCCESS,
+                amount,
+                balanceAfterAmount,
+                idempotencyKey,
+                description
+        );
+    }
+
+    private PaymentTransaction(
+            User user,
+            Long reservationId,
+            PaymentTransactionType type,
+            PaymentTransactionStatus status,
+            Long amount,
+            Long balanceAfterAmount,
+            String idempotencyKey,
+            String description
+    ) {
+        this.user = user;
+        this.reservationId = reservationId;
+        this.type = type;
+        this.status = status;
+        this.amount = amount;
+        this.balanceAfterAmount = balanceAfterAmount;
+        this.idempotencyKey = idempotencyKey;
+        this.description = description;
+    }
+
+    @PrePersist
+    void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransactionStatus.java
+++ b/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransactionStatus.java
@@ -1,0 +1,5 @@
+package com.ticketrush.domain.payment.entity;
+
+public enum PaymentTransactionStatus {
+    SUCCESS
+}

--- a/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransactionType.java
+++ b/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransactionType.java
@@ -1,0 +1,7 @@
+package com.ticketrush.domain.payment.entity;
+
+public enum PaymentTransactionType {
+    CHARGE,
+    PAYMENT,
+    REFUND
+}

--- a/src/main/java/com/ticketrush/domain/payment/repository/PaymentTransactionRepository.java
+++ b/src/main/java/com/ticketrush/domain/payment/repository/PaymentTransactionRepository.java
@@ -1,0 +1,23 @@
+package com.ticketrush.domain.payment.repository;
+
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
+import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentTransactionRepository extends JpaRepository<PaymentTransaction, Long> {
+
+    Optional<PaymentTransaction> findByIdempotencyKey(String idempotencyKey);
+
+    Optional<PaymentTransaction> findTopByReservationIdAndTypeAndStatusOrderByIdDesc(
+            Long reservationId,
+            PaymentTransactionType type,
+            PaymentTransactionStatus status
+    );
+
+    List<PaymentTransaction> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/ticketrush/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/ticketrush/domain/payment/service/PaymentService.java
@@ -1,0 +1,18 @@
+package com.ticketrush.domain.payment.service;
+
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+
+import java.util.List;
+
+public interface PaymentService {
+
+    PaymentTransaction chargeWallet(Long userId, Long amount, String idempotencyKey, String description);
+
+    PaymentTransaction payForReservation(Long userId, Long reservationId, Long amount, String idempotencyKey);
+
+    PaymentTransaction refundReservation(Long userId, Long reservationId, String idempotencyKey);
+
+    long getWalletBalance(Long userId);
+
+    List<PaymentTransaction> getTransactions(Long userId, int limit);
+}

--- a/src/main/java/com/ticketrush/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ticketrush/domain/payment/service/PaymentServiceImpl.java
@@ -1,0 +1,154 @@
+package com.ticketrush.domain.payment.service;
+
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
+import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import com.ticketrush.domain.payment.repository.PaymentTransactionRepository;
+import com.ticketrush.domain.user.User;
+import com.ticketrush.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService {
+
+    private final PaymentTransactionRepository paymentTransactionRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public PaymentTransaction chargeWallet(Long userId, Long amount, String idempotencyKey, String description) {
+        String key = normalizeIdempotencyKey(idempotencyKey, "wallet-charge-" + userId + "-" + System.currentTimeMillis());
+        PaymentTransaction existing = findByIdempotencyKey(key);
+        if (existing != null) {
+            return existing;
+        }
+
+        long normalizedAmount = validatePositiveAmount(amount);
+        User user = getUserForUpdate(userId);
+        user.chargeWallet(normalizedAmount);
+
+        return paymentTransactionRepository.save(PaymentTransaction.charge(
+                user,
+                normalizedAmount,
+                user.getWalletBalanceAmountSafe(),
+                key,
+                normalizeDescription(description, "WALLET_CHARGE")
+        ));
+    }
+
+    @Override
+    @Transactional
+    public PaymentTransaction payForReservation(Long userId, Long reservationId, Long amount, String idempotencyKey) {
+        String key = normalizeIdempotencyKey(idempotencyKey, "reservation-payment-" + reservationId);
+        PaymentTransaction existing = findByIdempotencyKey(key);
+        if (existing != null) {
+            return existing;
+        }
+
+        long normalizedAmount = validatePositiveAmount(amount);
+        User user = getUserForUpdate(userId);
+        user.payFromWallet(normalizedAmount);
+
+        return paymentTransactionRepository.save(PaymentTransaction.payment(
+                user,
+                reservationId,
+                normalizedAmount,
+                user.getWalletBalanceAmountSafe(),
+                key,
+                "RESERVATION_PAYMENT"
+        ));
+    }
+
+    @Override
+    @Transactional
+    public PaymentTransaction refundReservation(Long userId, Long reservationId, String idempotencyKey) {
+        String key = normalizeIdempotencyKey(idempotencyKey, "reservation-refund-" + reservationId);
+        PaymentTransaction existing = findByIdempotencyKey(key);
+        if (existing != null) {
+            return existing;
+        }
+
+        PaymentTransaction paidTransaction = paymentTransactionRepository
+                .findTopByReservationIdAndTypeAndStatusOrderByIdDesc(
+                        reservationId,
+                        PaymentTransactionType.PAYMENT,
+                        PaymentTransactionStatus.SUCCESS
+                )
+                .orElseThrow(() -> new IllegalStateException("No successful payment found for reservation: " + reservationId));
+
+        if (!paidTransaction.getUser().getId().equals(userId)) {
+            throw new IllegalStateException("Refund user mismatch for reservation: " + reservationId);
+        }
+
+        User user = getUserForUpdate(userId);
+        user.chargeWallet(paidTransaction.getAmount());
+
+        return paymentTransactionRepository.save(PaymentTransaction.refund(
+                user,
+                reservationId,
+                paidTransaction.getAmount(),
+                user.getWalletBalanceAmountSafe(),
+                key,
+                "RESERVATION_REFUND"
+        ));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long getWalletBalance(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+        return user.getWalletBalanceAmountSafe();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PaymentTransaction> getTransactions(Long userId, int limit) {
+        int normalizedLimit = normalizeLimit(limit);
+        return paymentTransactionRepository.findByUserIdOrderByIdDesc(userId, PageRequest.of(0, normalizedLimit));
+    }
+
+    private PaymentTransaction findByIdempotencyKey(String idempotencyKey) {
+        return paymentTransactionRepository.findByIdempotencyKey(idempotencyKey).orElse(null);
+    }
+
+    private User getUserForUpdate(Long userId) {
+        return userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+    }
+
+    private long validatePositiveAmount(Long amount) {
+        if (amount == null || amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        return amount;
+    }
+
+    private String normalizeIdempotencyKey(String value, String fallback) {
+        if (!StringUtils.hasText(value)) {
+            return fallback;
+        }
+        return value.trim();
+    }
+
+    private String normalizeDescription(String value, String fallback) {
+        if (!StringUtils.hasText(value)) {
+            return fallback;
+        }
+        return value.trim();
+    }
+
+    private int normalizeLimit(int limit) {
+        if (limit <= 0) {
+            return 20;
+        }
+        return Math.min(limit, 100);
+    }
+}

--- a/src/main/java/com/ticketrush/domain/user/User.java
+++ b/src/main/java/com/ticketrush/domain/user/User.java
@@ -52,6 +52,9 @@ public class User {
     @Column(name = "display_name", length = 100)
     private String displayName;
 
+    @Column(name = "wallet_balance_amount", nullable = false)
+    private Long walletBalanceAmount;
+
     public User(String username) {
         this(username, UserTier.BASIC);
     }
@@ -64,6 +67,7 @@ public class User {
         this.username = username;
         this.tier = tier == null ? UserTier.BASIC : tier;
         this.role = role == null ? UserRole.USER : role;
+        this.walletBalanceAmount = 200_000L;
     }
 
     public static User socialUser(
@@ -112,6 +116,30 @@ public class User {
     public void updateSocialProfile(String email, String displayName) {
         this.email = normalizeNullable(email);
         this.displayName = normalizeNullable(displayName);
+    }
+
+    public long getWalletBalanceAmountSafe() {
+        return walletBalanceAmount == null ? 0L : walletBalanceAmount;
+    }
+
+    public void chargeWallet(long amount) {
+        validatePositiveAmount(amount);
+        this.walletBalanceAmount = getWalletBalanceAmountSafe() + amount;
+    }
+
+    public void payFromWallet(long amount) {
+        validatePositiveAmount(amount);
+        long currentBalance = getWalletBalanceAmountSafe();
+        if (currentBalance < amount) {
+            throw new IllegalStateException("Insufficient wallet balance.");
+        }
+        this.walletBalanceAmount = currentBalance - amount;
+    }
+
+    private void validatePositiveAmount(long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
     }
 
     private String normalizeNullable(String value) {

--- a/src/main/java/com/ticketrush/domain/user/UserRepository.java
+++ b/src/main/java/com/ticketrush/domain/user/UserRepository.java
@@ -1,6 +1,10 @@
 package com.ticketrush.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import jakarta.persistence.LockModeType;
 
 import java.util.Optional;
 
@@ -8,4 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     Optional<User> findBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.id = :id")
+    Optional<User> findByIdForUpdate(Long id);
 }

--- a/src/main/java/com/ticketrush/global/config/PaymentProperties.java
+++ b/src/main/java/com/ticketrush/global/config/PaymentProperties.java
@@ -1,0 +1,18 @@
+package com.ticketrush.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.payment")
+public class PaymentProperties {
+
+    /**
+     * 예약 확정 시 차감되는 기본 티켓 금액.
+     */
+    private long defaultTicketPriceAmount = 100_000L;
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -39,6 +39,8 @@ app:
   reservation:
     hold-ttl-seconds: 300
     expire-check-delay-millis: 5000
+  payment:
+    default-ticket-price-amount: 100000
   waiting-queue:
     queue-key-prefix: "waiting-queue:"
     active-key-prefix: "active-user:"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -58,6 +58,8 @@ app:
   reservation:
     hold-ttl-seconds: 300
     expire-check-delay-millis: 5000
+  payment:
+    default-ticket-price-amount: 100000
   waiting-queue:
     queue-key-prefix: "waiting-queue:"
     active-key-prefix: "active-user:"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ app:
   reservation:
     hold-ttl-seconds: 300
     expire-check-delay-millis: 5000
+  payment:
+    default-ticket-price-amount: 100000
   push:
     mode: ${APP_PUSH_MODE:sse}
   waiting-queue:

--- a/src/test/java/com/ticketrush/domain/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/ticketrush/domain/payment/service/PaymentServiceIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.ticketrush.domain.payment.service;
+
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import com.ticketrush.domain.user.User;
+import com.ticketrush.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(PaymentServiceImpl.class)
+class PaymentServiceIntegrationTest {
+
+    @jakarta.annotation.Resource
+    private PaymentService paymentService;
+
+    @jakarta.annotation.Resource
+    private UserRepository userRepository;
+
+    @Test
+    void chargeWallet_shouldIncreaseBalanceAndRecordTransaction() {
+        User user = userRepository.save(new User("payment-charge-user-" + System.nanoTime()));
+
+        PaymentTransaction tx = paymentService.chargeWallet(
+                user.getId(),
+                50_000L,
+                "charge-" + user.getId(),
+                "TEST_CHARGE"
+        );
+
+        assertThat(tx.getType()).isEqualTo(PaymentTransactionType.CHARGE);
+        assertThat(paymentService.getWalletBalance(user.getId())).isEqualTo(250_000L);
+    }
+
+    @Test
+    void payForReservation_shouldDecreaseBalanceAndRecordTransaction() {
+        User user = userRepository.save(new User("payment-pay-user-" + System.nanoTime()));
+
+        PaymentTransaction tx = paymentService.payForReservation(
+                user.getId(),
+                101L,
+                120_000L,
+                "reservation-payment-101"
+        );
+
+        assertThat(tx.getType()).isEqualTo(PaymentTransactionType.PAYMENT);
+        assertThat(paymentService.getWalletBalance(user.getId())).isEqualTo(80_000L);
+    }
+
+    @Test
+    void payForReservation_shouldFailWhenBalanceIsInsufficient() {
+        User user = userRepository.save(new User("payment-insufficient-user-" + System.nanoTime()));
+
+        assertThatThrownBy(() -> paymentService.payForReservation(
+                user.getId(),
+                201L,
+                300_000L,
+                "reservation-payment-201"
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Insufficient wallet balance");
+    }
+
+    @Test
+    void refundReservation_shouldRestoreBalanceFromPaymentTransaction() {
+        User user = userRepository.save(new User("payment-refund-user-" + System.nanoTime()));
+        paymentService.payForReservation(user.getId(), 301L, 110_000L, "reservation-payment-301");
+
+        PaymentTransaction refundTx = paymentService.refundReservation(
+                user.getId(),
+                301L,
+                "reservation-refund-301"
+        );
+
+        assertThat(refundTx.getType()).isEqualTo(PaymentTransactionType.REFUND);
+        assertThat(paymentService.getWalletBalance(user.getId())).isEqualTo(200_000L);
+    }
+
+    @Test
+    void chargeWallet_shouldBeIdempotentWithSameKey() {
+        User user = userRepository.save(new User("payment-idempotent-user-" + System.nanoTime()));
+        String key = "charge-idempotent-" + user.getId();
+
+        PaymentTransaction first = paymentService.chargeWallet(user.getId(), 10_000L, key, "IDEMPOTENT_CHARGE");
+        PaymentTransaction second = paymentService.chargeWallet(user.getId(), 10_000L, key, "IDEMPOTENT_CHARGE");
+
+        assertThat(first.getId()).isEqualTo(second.getId());
+        assertThat(paymentService.getWalletBalance(user.getId())).isEqualTo(210_000L);
+    }
+}


### PR DESCRIPTION
## Related Issue
- Closes #5

## Summary
- Add wallet balance + payment ledger domain
- Integrate reservation confirm/refund with wallet deduction/refund
- Add wallet APIs for charge/balance/ledger

## Main Changes
- User wallet
  - `users.wallet_balance_amount` field (default 200000)
  - pessimistic lock query (`findByIdForUpdate`) for balance mutation consistency
- Payment ledger
  - `payment_transactions` entity + repository
  - transaction types: CHARGE, PAYMENT, REFUND
  - idempotency key support
- Reservation payment integration
  - confirm: deduct wallet by `app.payment.default-ticket-price-amount`
  - refund: restore amount from reservation payment ledger
- New APIs
  - `GET /api/users/{userId}/wallet`
  - `POST /api/users/{userId}/wallet/charges`
  - `GET /api/users/{userId}/wallet/transactions`
- Config
  - `app.payment.default-ticket-price-amount`
- Tests & scripts
  - `PaymentServiceIntegrationTest`
  - reservation lifecycle test assertions for wallet deduction/refund
  - API script `v14-wallet-payment-flow.sh`

## Verification
- `./gradlew test` passed
