### PR TITLE
[Auth] OAuth/JWT session hardening (expiry/refresh/logout invalidation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ make test-k6
 - 예약 결제 연동:
   - `v6/v7 confirm`에서 기본 티켓 금액(`app.payment.default-ticket-price-amount`) 차감
   - `v6/v7 refund`에서 해당 예약 결제 금액 환불
+- 인증 세션 무효화:
+  - `POST /api/auth/logout` 호출 시 `Authorization: Bearer <accessToken>` + body `refreshToken` 동시 전달 필요
+  - 로그아웃 처리 시 refresh 토큰 즉시 revoke + access 토큰은 만료 시각까지 denylist 처리
 
 ---
 

--- a/scripts/http/auth-social.http
+++ b/scripts/http/auth-social.http
@@ -101,6 +101,19 @@ GET {{host}}/login/oauth2/code/naver?code=sample-code&state={{naverState}}
 
 ### 11) 로그아웃
 POST {{host}}/api/auth/logout
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "refreshToken": "{{refreshToken}}"
+}
+
+### 12) 로그아웃 이후 access 재사용 차단 확인 (401 예상)
+GET {{host}}/api/auth/me
+Authorization: Bearer {{accessToken}}
+
+### 13) 로그아웃 이후 refresh 재사용 차단 확인 (400 예상)
+POST {{host}}/api/auth/token/refresh
 Content-Type: application/json
 
 {

--- a/src/main/java/com/ticketrush/domain/auth/config/AccessTokenDenylistConfig.java
+++ b/src/main/java/com/ticketrush/domain/auth/config/AccessTokenDenylistConfig.java
@@ -1,0 +1,30 @@
+package com.ticketrush.domain.auth.config;
+
+import com.ticketrush.domain.auth.service.AccessTokenDenylistService;
+import com.ticketrush.domain.auth.service.InMemoryAccessTokenDenylistService;
+import com.ticketrush.domain.auth.service.RedisAccessTokenDenylistService;
+import com.ticketrush.global.config.AuthJwtProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class AccessTokenDenylistConfig {
+
+    @Bean
+    @ConditionalOnBean(StringRedisTemplate.class)
+    AccessTokenDenylistService redisAccessTokenDenylistService(
+            StringRedisTemplate redisTemplate,
+            AuthJwtProperties authJwtProperties
+    ) {
+        return new RedisAccessTokenDenylistService(redisTemplate, authJwtProperties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AccessTokenDenylistService.class)
+    AccessTokenDenylistService inMemoryAccessTokenDenylistService() {
+        return new InMemoryAccessTokenDenylistService();
+    }
+}

--- a/src/main/java/com/ticketrush/domain/auth/service/AccessTokenDenylistService.java
+++ b/src/main/java/com/ticketrush/domain/auth/service/AccessTokenDenylistService.java
@@ -1,0 +1,9 @@
+package com.ticketrush.domain.auth.service;
+
+import java.time.Instant;
+
+public interface AccessTokenDenylistService {
+    void revoke(String tokenId, Instant expiresAt);
+
+    boolean isRevoked(String tokenId);
+}

--- a/src/main/java/com/ticketrush/domain/auth/service/AuthSessionService.java
+++ b/src/main/java/com/ticketrush/domain/auth/service/AuthSessionService.java
@@ -8,5 +8,5 @@ public interface AuthSessionService {
 
     AuthTokenPair refresh(String refreshTokenValue);
 
-    void logout(String refreshTokenValue);
+    void logout(String refreshTokenValue, String accessTokenValue);
 }

--- a/src/main/java/com/ticketrush/domain/auth/service/AuthSessionServiceImpl.java
+++ b/src/main/java/com/ticketrush/domain/auth/service/AuthSessionServiceImpl.java
@@ -19,18 +19,20 @@ import java.util.UUID;
 public class AuthSessionServiceImpl implements AuthSessionService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final AccessTokenDenylistService accessTokenDenylistService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
 
     @Transactional
     public AuthTokenPair issueFor(User user) {
-        String tokenId = UUID.randomUUID().toString();
-        String accessToken = jwtTokenProvider.createAccessToken(user);
-        String refreshToken = jwtTokenProvider.createRefreshToken(user, tokenId);
+        String accessTokenId = UUID.randomUUID().toString();
+        String refreshTokenId = UUID.randomUUID().toString();
+        String accessToken = jwtTokenProvider.createAccessToken(user, accessTokenId);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user, refreshTokenId);
 
         LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
         LocalDateTime refreshExpiresAt = now.plusSeconds(jwtTokenProvider.refreshTokenExpiresInSeconds());
-        refreshTokenRepository.save(new RefreshToken(user, tokenId, refreshExpiresAt, now));
+        refreshTokenRepository.save(new RefreshToken(user, refreshTokenId, refreshExpiresAt, now));
 
         return new AuthTokenPair(
                 accessToken,
@@ -42,19 +44,8 @@ public class AuthSessionServiceImpl implements AuthSessionService {
 
     @Transactional
     public AuthTokenPair refresh(String refreshTokenValue) {
-        if (refreshTokenValue == null || refreshTokenValue.isBlank()) {
-            throw new IllegalArgumentException("refresh token is required");
-        }
-
-        Claims claims = jwtTokenProvider.parseClaims(refreshTokenValue.trim());
-        if (!JwtTokenProvider.TOKEN_TYPE_REFRESH.equals(jwtTokenProvider.extractTokenType(claims))) {
-            throw new IllegalArgumentException("invalid refresh token type");
-        }
-
-        String tokenId = claims.getId();
-        if (tokenId == null || tokenId.isBlank()) {
-            throw new IllegalArgumentException("invalid refresh token id");
-        }
+        Claims claims = parseRefreshClaims(refreshTokenValue);
+        String tokenId = jwtTokenProvider.extractTokenId(claims);
 
         RefreshToken refreshToken = refreshTokenRepository.findByTokenId(tokenId)
                 .orElseThrow(() -> new IllegalArgumentException("refresh token not found"));
@@ -77,23 +68,49 @@ public class AuthSessionServiceImpl implements AuthSessionService {
     }
 
     @Transactional
-    public void logout(String refreshTokenValue) {
+    public void logout(String refreshTokenValue, String accessTokenValue) {
+        Claims refreshClaims = parseRefreshClaims(refreshTokenValue);
+        Claims accessClaims = parseAccessClaims(accessTokenValue);
+
+        Long refreshUserId = jwtTokenProvider.extractUserId(refreshClaims);
+        Long accessUserId = jwtTokenProvider.extractUserId(accessClaims);
+        if (!refreshUserId.equals(accessUserId)) {
+            throw new IllegalArgumentException("logout token user mismatch");
+        }
+
+        String tokenId = jwtTokenProvider.extractTokenId(refreshClaims);
+
+        RefreshToken refreshToken = refreshTokenRepository.findByTokenId(tokenId)
+                .orElseThrow(() -> new IllegalArgumentException("refresh token not found"));
+        if (!refreshToken.getUser().getId().equals(refreshUserId)) {
+            throw new IllegalArgumentException("refresh token user mismatch");
+        }
+
+        refreshToken.revoke(LocalDateTime.now(ZoneOffset.UTC));
+
+        String accessTokenId = jwtTokenProvider.extractTokenId(accessClaims);
+        accessTokenDenylistService.revoke(accessTokenId, jwtTokenProvider.extractExpiration(accessClaims));
+    }
+
+    private Claims parseRefreshClaims(String refreshTokenValue) {
         if (refreshTokenValue == null || refreshTokenValue.isBlank()) {
             throw new IllegalArgumentException("refresh token is required");
         }
-
         Claims claims = jwtTokenProvider.parseClaims(refreshTokenValue.trim());
         if (!JwtTokenProvider.TOKEN_TYPE_REFRESH.equals(jwtTokenProvider.extractTokenType(claims))) {
             throw new IllegalArgumentException("invalid refresh token type");
         }
+        return claims;
+    }
 
-        String tokenId = claims.getId();
-        if (tokenId == null || tokenId.isBlank()) {
-            throw new IllegalArgumentException("invalid refresh token id");
+    private Claims parseAccessClaims(String accessTokenValue) {
+        if (accessTokenValue == null || accessTokenValue.isBlank()) {
+            throw new IllegalArgumentException("access token is required");
         }
-
-        RefreshToken refreshToken = refreshTokenRepository.findByTokenId(tokenId)
-                .orElseThrow(() -> new IllegalArgumentException("refresh token not found"));
-        refreshToken.revoke(LocalDateTime.now(ZoneOffset.UTC));
+        Claims claims = jwtTokenProvider.parseClaims(accessTokenValue.trim());
+        if (!JwtTokenProvider.TOKEN_TYPE_ACCESS.equals(jwtTokenProvider.extractTokenType(claims))) {
+            throw new IllegalArgumentException("invalid access token type");
+        }
+        return claims;
     }
 }

--- a/src/main/java/com/ticketrush/domain/auth/service/InMemoryAccessTokenDenylistService.java
+++ b/src/main/java/com/ticketrush/domain/auth/service/InMemoryAccessTokenDenylistService.java
@@ -1,0 +1,48 @@
+package com.ticketrush.domain.auth.service;
+
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryAccessTokenDenylistService implements AccessTokenDenylistService {
+
+    private final Map<String, Instant> revokedUntilByTokenId = new ConcurrentHashMap<>();
+
+    @Override
+    public void revoke(String tokenId, Instant expiresAt) {
+        if (tokenId == null || tokenId.isBlank()) {
+            return;
+        }
+        Instant normalizedExpiresAt = expiresAt == null ? Instant.now().plusSeconds(1) : expiresAt;
+        revokedUntilByTokenId.put(tokenId, normalizedExpiresAt);
+        cleanupExpired(Instant.now());
+    }
+
+    @Override
+    public boolean isRevoked(String tokenId) {
+        if (tokenId == null || tokenId.isBlank()) {
+            return false;
+        }
+        Instant now = Instant.now();
+        Instant revokedUntil = revokedUntilByTokenId.get(tokenId);
+        if (revokedUntil == null) {
+            return false;
+        }
+        if (!revokedUntil.isAfter(now)) {
+            revokedUntilByTokenId.remove(tokenId);
+            return false;
+        }
+        return true;
+    }
+
+    private void cleanupExpired(Instant now) {
+        Iterator<Map.Entry<String, Instant>> iterator = revokedUntilByTokenId.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Instant> entry = iterator.next();
+            if (!entry.getValue().isAfter(now)) {
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/src/main/java/com/ticketrush/domain/auth/service/RedisAccessTokenDenylistService.java
+++ b/src/main/java/com/ticketrush/domain/auth/service/RedisAccessTokenDenylistService.java
@@ -1,0 +1,97 @@
+package com.ticketrush.domain.auth.service;
+
+import com.ticketrush.global.config.AuthJwtProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class RedisAccessTokenDenylistService implements AccessTokenDenylistService {
+
+    private static final Duration MIN_TTL = Duration.ofSeconds(1);
+
+    private final StringRedisTemplate redisTemplate;
+    private final AuthJwtProperties authJwtProperties;
+    private final Map<String, Instant> fallbackRevokedUntilByTokenId = new ConcurrentHashMap<>();
+
+    public RedisAccessTokenDenylistService(
+            StringRedisTemplate redisTemplate,
+            AuthJwtProperties authJwtProperties
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.authJwtProperties = authJwtProperties;
+    }
+
+    @Override
+    public void revoke(String tokenId, Instant expiresAt) {
+        if (!StringUtils.hasText(tokenId)) {
+            return;
+        }
+
+        Instant normalizedExpiresAt = expiresAt == null ? Instant.now().plusSeconds(1) : expiresAt;
+        Duration ttl = Duration.between(Instant.now(), normalizedExpiresAt);
+        if (ttl.isZero() || ttl.isNegative()) {
+            ttl = MIN_TTL;
+        }
+
+        fallbackRevokedUntilByTokenId.put(tokenId, normalizedExpiresAt);
+        cleanupFallback(Instant.now());
+
+        try {
+            redisTemplate.opsForValue().set(key(tokenId), "1", ttl);
+        } catch (RuntimeException ex) {
+            log.warn(">>>> [Auth] access token denylist redis write failed, using fallback map. tokenId={}", tokenId, ex);
+        }
+    }
+
+    @Override
+    public boolean isRevoked(String tokenId) {
+        if (!StringUtils.hasText(tokenId)) {
+            return false;
+        }
+
+        Instant now = Instant.now();
+        if (isFallbackRevoked(tokenId, now)) {
+            return true;
+        }
+
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key(tokenId)));
+        } catch (RuntimeException ex) {
+            log.warn(">>>> [Auth] access token denylist redis read failed, using fallback map. tokenId={}", tokenId, ex);
+            return isFallbackRevoked(tokenId, now);
+        }
+    }
+
+    private boolean isFallbackRevoked(String tokenId, Instant now) {
+        Instant revokedUntil = fallbackRevokedUntilByTokenId.get(tokenId);
+        if (revokedUntil == null) {
+            return false;
+        }
+        if (!revokedUntil.isAfter(now)) {
+            fallbackRevokedUntilByTokenId.remove(tokenId);
+            return false;
+        }
+        return true;
+    }
+
+    private void cleanupFallback(Instant now) {
+        Iterator<Map.Entry<String, Instant>> iterator = fallbackRevokedUntilByTokenId.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Instant> entry = iterator.next();
+            if (!entry.getValue().isAfter(now)) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private String key(String tokenId) {
+        return authJwtProperties.getAccessTokenBlocklistKeyPrefix() + tokenId;
+    }
+}

--- a/src/main/java/com/ticketrush/global/config/AuthJwtProperties.java
+++ b/src/main/java/com/ticketrush/global/config/AuthJwtProperties.java
@@ -14,4 +14,5 @@ public class AuthJwtProperties {
     private String secret;
     private long accessTokenSeconds = 1800;
     private long refreshTokenSeconds = 1209600;
+    private String accessTokenBlocklistKeyPrefix = "auth:access-blocklist:";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,7 @@ app:
       secret: ${AUTH_JWT_SECRET:ticketrush-local-dev-jwt-secret-key-change-this-value}
       access-token-seconds: ${AUTH_ACCESS_TOKEN_SECONDS:1800}
       refresh-token-seconds: ${AUTH_REFRESH_TOKEN_SECONDS:1209600}
+      access-token-blocklist-key-prefix: ${AUTH_ACCESS_TOKEN_BLOCKLIST_KEY_PREFIX:auth:access-blocklist:}
   frontend:
     u1-callback-url: ${U1_CALLBACK_URL:/ux/u1/callback.html}
     allowed-origins: ${FRONTEND_ALLOWED_ORIGINS:http://localhost:8080,http://127.0.0.1:8080}

--- a/src/test/java/com/ticketrush/api/controller/AuthSecurityIntegrationTest.java
+++ b/src/test/java/com/ticketrush/api/controller/AuthSecurityIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.api.controller;
 
 import com.ticketrush.domain.auth.security.JwtAuthenticationFilter;
+import com.ticketrush.domain.auth.service.AccessTokenDenylistService;
 import com.ticketrush.domain.auth.service.AuthSessionService;
 import com.ticketrush.domain.auth.service.JwtTokenProvider;
 import com.ticketrush.domain.user.User;
@@ -43,6 +44,9 @@ class AuthSecurityIntegrationTest {
 
     @MockBean
     private AuthSessionService authSessionService;
+
+    @MockBean
+    private AccessTokenDenylistService accessTokenDenylistService;
 
     @MockBean
     private UserRepository userRepository;

--- a/src/test/java/com/ticketrush/domain/auth/service/AuthSessionServiceTest.java
+++ b/src/test/java/com/ticketrush/domain/auth/service/AuthSessionServiceTest.java
@@ -17,7 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
-@Import({AuthSessionServiceImpl.class, JwtTokenProvider.class, AuthJwtProperties.class})
+@Import({
+        AuthSessionServiceImpl.class,
+        JwtTokenProvider.class,
+        AuthJwtProperties.class,
+        InMemoryAccessTokenDenylistService.class
+})
 @TestPropertySource(properties = {
         "app.auth.jwt.secret=test-auth-session-secret-key-which-is-long-enough",
         "app.auth.jwt.access-token-seconds=300",
@@ -33,6 +38,12 @@ class AuthSessionServiceTest {
 
     @jakarta.annotation.Resource
     private UserRepository userRepository;
+
+    @jakarta.annotation.Resource
+    private JwtTokenProvider jwtTokenProvider;
+
+    @jakarta.annotation.Resource
+    private AccessTokenDenylistService accessTokenDenylistService;
 
     @Test
     void issueFor_shouldPersistRefreshTokenAndReturnTokenPair() {
@@ -67,10 +78,35 @@ class AuthSessionServiceTest {
     void refresh_shouldFailWhenTokenAlreadyRevoked() {
         User user = userRepository.save(new User("auth-user-3", UserTier.BASIC, UserRole.USER));
         AuthTokenPair first = authSessionService.issueFor(user);
-        authSessionService.logout(first.getRefreshToken());
+        authSessionService.logout(first.getRefreshToken(), first.getAccessToken());
 
         assertThatThrownBy(() -> authSessionService.refresh(first.getRefreshToken()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("revoked");
+    }
+
+    @Test
+    void logout_shouldRevokeRefreshTokenAndAccessToken() {
+        User user = userRepository.save(new User("auth-user-4", UserTier.BASIC, UserRole.USER));
+        AuthTokenPair pair = authSessionService.issueFor(user);
+        String accessTokenId = jwtTokenProvider.extractTokenId(jwtTokenProvider.parseClaims(pair.getAccessToken()));
+
+        authSessionService.logout(pair.getRefreshToken(), pair.getAccessToken());
+
+        RefreshToken refreshToken = refreshTokenRepository.findAll().get(0);
+        assertThat(refreshToken.isRevoked()).isTrue();
+        assertThat(accessTokenDenylistService.isRevoked(accessTokenId)).isTrue();
+    }
+
+    @Test
+    void logout_shouldFailWhenAccessAndRefreshTokenUserMismatch() {
+        User userA = userRepository.save(new User("auth-user-5a", UserTier.BASIC, UserRole.USER));
+        User userB = userRepository.save(new User("auth-user-5b", UserTier.BASIC, UserRole.USER));
+        AuthTokenPair pairA = authSessionService.issueFor(userA);
+        AuthTokenPair pairB = authSessionService.issueFor(userB);
+
+        assertThatThrownBy(() -> authSessionService.logout(pairA.getRefreshToken(), pairB.getAccessToken()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mismatch");
     }
 }


### PR DESCRIPTION
## Summary
- add access-token denylist abstraction and Redis/InMemory implementations
- revoke both refresh token and current access token on logout
- validate token type/user consistency for refresh and logout flows
- reject revoked access tokens in JWT authentication filter
- update auth script/readme for new logout contract

## Verification
- ./gradlew test

Closes #7