### PR TITLE
[Auth] logout/session regression follow-up hardening

### DIFF
--- a/scripts/http/auth-social.http
+++ b/scripts/http/auth-social.http
@@ -111,6 +111,11 @@ Content-Type: application/json
 ### 12) 로그아웃 이후 access 재사용 차단 확인 (401 예상)
 GET {{host}}/api/auth/me
 Authorization: Bearer {{accessToken}}
+> {%
+client.test("logout blocks access token reuse", function() {
+  client.assert(response.status === 401, "expected 401");
+});
+%}
 
 ### 13) 로그아웃 이후 refresh 재사용 차단 확인 (400 예상)
 POST {{host}}/api/auth/token/refresh
@@ -119,3 +124,8 @@ Content-Type: application/json
 {
   "refreshToken": "{{refreshToken}}"
 }
+> {%
+client.test("logout blocks refresh token reuse", function() {
+  client.assert(response.status === 400, "expected 400");
+});
+%}

--- a/src/test/java/com/ticketrush/domain/auth/service/AuthSessionServiceTest.java
+++ b/src/test/java/com/ticketrush/domain/auth/service/AuthSessionServiceTest.java
@@ -109,4 +109,24 @@ class AuthSessionServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("mismatch");
     }
+
+    @Test
+    void logout_shouldFailWhenRefreshTokenMissing() {
+        User user = userRepository.save(new User("auth-user-6", UserTier.BASIC, UserRole.USER));
+        AuthTokenPair pair = authSessionService.issueFor(user);
+
+        assertThatThrownBy(() -> authSessionService.logout(null, pair.getAccessToken()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("refresh token is required");
+    }
+
+    @Test
+    void logout_shouldFailWhenAccessTokenMissing() {
+        User user = userRepository.save(new User("auth-user-7", UserTier.BASIC, UserRole.USER));
+        AuthTokenPair pair = authSessionService.issueFor(user);
+
+        assertThatThrownBy(() -> authSessionService.logout(pair.getRefreshToken(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("access token is required");
+    }
 }


### PR DESCRIPTION
## Summary
- add auth regression tests for revoked access token and missing access token on logout
- add service-level regression tests for logout token-missing guards
- add expected status assertions to auth-social.http logout reuse checks

## Verification
- ./gradlew test --tests "com.ticketrush.api.controller.AuthSecurityIntegrationTest" --tests "com.ticketrush.domain.auth.service.AuthSessionServiceTest"
- ./gradlew test

Reopen/Update existing issue (same scope): #7