### PR TITLE
[Auth] auth-social CI-safe e2e pipeline automation

### DIFF
--- a/.github/workflows/auth-social-e2e-pipeline.yml
+++ b/.github/workflows/auth-social-e2e-pipeline.yml
@@ -1,0 +1,55 @@
+name: auth-social-e2e-pipeline
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/main/java/com/ticketrush/api/controller/SocialAuthController.java'
+      - 'src/main/java/com/ticketrush/domain/auth/**'
+      - 'src/main/java/com/ticketrush/global/config/SecurityConfig.java'
+      - 'src/test/java/com/ticketrush/api/controller/**'
+      - 'src/test/java/com/ticketrush/domain/auth/**'
+      - 'scripts/api/run-auth-social-e2e-pipeline.sh'
+      - 'Makefile'
+      - '.github/workflows/auth-social-e2e-pipeline.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/main/java/com/ticketrush/api/controller/SocialAuthController.java'
+      - 'src/main/java/com/ticketrush/domain/auth/**'
+      - 'src/main/java/com/ticketrush/global/config/SecurityConfig.java'
+      - 'src/test/java/com/ticketrush/api/controller/**'
+      - 'src/test/java/com/ticketrush/domain/auth/**'
+      - 'scripts/api/run-auth-social-e2e-pipeline.sh'
+      - 'Makefile'
+      - '.github/workflows/auth-social-e2e-pipeline.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Ensure executable bits
+        run: |
+          chmod +x ./gradlew
+          chmod +x ./scripts/api/*.sh
+
+      - name: Run auth-social CI-safe pipeline
+        run: ./scripts/api/run-auth-social-e2e-pipeline.sh
+
+      - name: Upload pipeline report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: auth-social-e2e-report
+          path: .codex/tmp/ticket-core-service/api-test/auth-social-e2e-latest.md
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for TicketRush API Testing
 
-.PHONY: help test-v1 test-v2 test-v3 test-v4 test-v5 test-v6 test-v7 test-v9 test-k6 test-k6-dashboard test-suite test-all setup-perms
+.PHONY: help test-v1 test-v2 test-v3 test-v4 test-v5 test-v6 test-v7 test-v9 test-k6 test-k6-dashboard test-suite test-auth-social-pipeline test-all setup-perms
 
 # 기본 명령어 (도움말)
 help:
@@ -17,6 +17,7 @@ help:
 	@echo " make test-k6    : [perf] k6 대기열 부하 테스트"
 	@echo " make test-k6-dashboard : [perf] k6 + 웹 대시보드(5665) 실행"
 	@echo " make test-suite : 변경된 API 스크립트 실행 + 리포트 생성"
+	@echo " make test-auth-social-pipeline : auth-social CI-safe 파이프라인 테스트"
 	@echo " make test-all   : 모든 버전 순차 테스트"
 	@echo " make setup      : 스크립트 실행 권한 부여"
 	@echo "========================================================================"
@@ -58,6 +59,9 @@ test-k6-dashboard:
 
 test-suite:
 	bash ./scripts/api/run-api-script-tests.sh
+
+test-auth-social-pipeline:
+	bash ./scripts/api/run-auth-social-e2e-pipeline.sh
 
 # 실행 권한 부여
 setup:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ make test-suite
 make test-k6
 ```
 
+### 5. Auth-Social CI-safe 파이프라인 테스트
+```bash
+make test-auth-social-pipeline
+```
+
 - 로컬 `k6`가 없으면 Docker(`grafana/k6`) fallback으로 자동 실행됩니다.
 - 웹 대시보드 포함 실행: `make test-k6-dashboard` (기본 URL: `http://127.0.0.1:5665`)
 
@@ -58,6 +63,7 @@ make test-k6
 ## 검증/운영 포인트
 
 - API 스크립트 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/latest.md`
+- auth-social 파이프라인 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/auth-social-e2e-latest.md`
 - k6 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/k6/latest/k6-latest.md`
 - 실시간 푸시 모드 스위치: `APP_PUSH_MODE=sse|websocket` (기본값 `sse`)
 - WebSocket STOMP 엔드포인트: `/ws` (`/topic/waiting-queue/{concertId}/{userId}`, `/topic/reservations/{seatId}/{userId}`)

--- a/scripts/api/run-auth-social-e2e-pipeline.sh
+++ b/scripts/api/run-auth-social-e2e-pipeline.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_abs="$(cd "$script_dir/../.." && pwd)"
+repo_root="$(git -C "$project_abs" rev-parse --show-toplevel)"
+if [[ "$project_abs" == "$repo_root" ]]; then
+  project_root="."
+else
+  project_root="${project_abs#$repo_root/}"
+fi
+
+report_path="${project_root}/.codex/tmp/ticket-core-service/api-test/auth-social-e2e-latest.md"
+report_abs_path="${project_abs}/.codex/tmp/ticket-core-service/api-test/auth-social-e2e-latest.md"
+tmp_log="$(mktemp)"
+trap 'rm -f "$tmp_log"' EXIT
+
+declare -a tests=(
+  "com.ticketrush.api.controller.SocialAuthControllerIntegrationTest"
+  "com.ticketrush.domain.auth.service.SocialAuthServiceTest"
+  "com.ticketrush.api.controller.AuthSecurityIntegrationTest"
+  "com.ticketrush.domain.auth.service.AuthSessionServiceTest"
+)
+
+cmd=("./gradlew" "test")
+for test_name in "${tests[@]}"; do
+  cmd+=("--tests" "$test_name")
+done
+
+mkdir -p "$(dirname "$report_abs_path")"
+
+(
+  cd "$project_abs"
+  "${cmd[@]}"
+) >"$tmp_log" 2>&1 || {
+  cat >"$report_abs_path" <<EOF
+# Auth Social E2E Pipeline Report
+
+- Result: FAIL
+- Command: \`${cmd[*]}\`
+- Project Root: \`${project_root}\`
+
+## Tail Logs
+\`\`\`text
+$(tail -n 80 "$tmp_log")
+\`\`\`
+EOF
+  echo "[auth-social-e2e] failed"
+  echo "[auth-social-e2e] report: ${report_path}"
+  exit 1
+}
+
+cat >"$report_abs_path" <<EOF
+# Auth Social E2E Pipeline Report
+
+- Result: PASS
+- Command: \`${cmd[*]}\`
+- Project Root: \`${project_root}\`
+- Tests:
+$(for test_name in "${tests[@]}"; do echo "  - \`${test_name}\`"; done)
+EOF
+
+echo "[auth-social-e2e] passed"
+echo "[auth-social-e2e] report: ${report_path}"

--- a/src/test/java/com/ticketrush/api/controller/SocialAuthControllerIntegrationTest.java
+++ b/src/test/java/com/ticketrush/api/controller/SocialAuthControllerIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.ticketrush.api.controller;
+
+import com.ticketrush.domain.auth.model.AuthTokenPair;
+import com.ticketrush.domain.auth.model.SocialAuthorizeInfo;
+import com.ticketrush.domain.auth.model.SocialLoginResult;
+import com.ticketrush.domain.auth.security.JwtAuthenticationFilter;
+import com.ticketrush.domain.auth.service.AccessTokenDenylistService;
+import com.ticketrush.domain.auth.service.AuthSessionService;
+import com.ticketrush.domain.auth.service.JwtTokenProvider;
+import com.ticketrush.domain.auth.service.SocialAuthService;
+import com.ticketrush.domain.user.SocialProvider;
+import com.ticketrush.domain.user.User;
+import com.ticketrush.domain.user.UserTier;
+import com.ticketrush.global.config.AuthJwtProperties;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.interceptor.WaitingQueueInterceptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SocialAuthController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtTokenProvider.class, AuthJwtProperties.class})
+@TestPropertySource(properties = {
+        "app.auth.jwt.secret=test-social-auth-secret-key-which-is-long-enough",
+        "app.auth.jwt.access-token-seconds=300",
+        "app.auth.jwt.refresh-token-seconds=3600"
+})
+class SocialAuthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SocialAuthService socialAuthService;
+
+    @MockBean
+    private AuthSessionService authSessionService;
+
+    @MockBean
+    private AccessTokenDenylistService accessTokenDenylistService;
+
+    @MockBean
+    private WaitingQueueInterceptor waitingQueueInterceptor;
+
+    @Test
+    void authorizeUrl_shouldReturnProviderStateAndUrl() throws Exception {
+        SocialAuthorizeInfo info = new SocialAuthorizeInfo(
+                SocialProvider.KAKAO,
+                "state-fixed-1",
+                "https://kauth.kakao.com/oauth/authorize?client_id=fake&state=state-fixed-1"
+        );
+        when(socialAuthService.getAuthorizeInfo(SocialProvider.KAKAO, "state-fixed-1")).thenReturn(info);
+
+        mockMvc.perform(get("/api/auth/social/kakao/authorize-url")
+                        .param("state", "state-fixed-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.provider").value("kakao"))
+                .andExpect(jsonPath("$.state").value("state-fixed-1"))
+                .andExpect(jsonPath("$.authorizeUrl").value(info.getAuthorizeUrl()));
+    }
+
+    @Test
+    void exchangeCode_shouldReturnTokenPairAndUserProfile() throws Exception {
+        User user = User.socialUser(
+                "kakao_user_501",
+                UserTier.BASIC,
+                SocialProvider.KAKAO,
+                "kakao-social-501",
+                "kakao501@example.com",
+                "Kakao User 501"
+        );
+        ReflectionTestUtils.setField(user, "id", 501L);
+
+        SocialLoginResult loginResult = new SocialLoginResult(user, true);
+        AuthTokenPair tokenPair = new AuthTokenPair("access-token-501", "refresh-token-501", 300, 3600);
+
+        when(socialAuthService.login(SocialProvider.KAKAO, "kakao-code-501", "state-fixed-1"))
+                .thenReturn(loginResult);
+        when(authSessionService.issueFor(any(User.class))).thenReturn(tokenPair);
+
+        mockMvc.perform(post("/api/auth/social/kakao/exchange")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"code\":\"kakao-code-501\",\"state\":\"state-fixed-1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(501L))
+                .andExpect(jsonPath("$.provider").value("kakao"))
+                .andExpect(jsonPath("$.socialId").value("kakao-social-501"))
+                .andExpect(jsonPath("$.newUser").value(true))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.accessToken").value("access-token-501"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-token-501"))
+                .andExpect(jsonPath("$.accessTokenExpiresInSeconds").value(300))
+                .andExpect(jsonPath("$.refreshTokenExpiresInSeconds").value(3600));
+    }
+
+    @Test
+    void authorizeUrl_shouldReturnBadRequestForUnsupportedProvider() throws Exception {
+        mockMvc.perform(get("/api/auth/social/unsupported/authorize-url"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Unsupported provider")));
+    }
+}


### PR DESCRIPTION
## Summary
- add SocialAuthControllerIntegrationTest for authorize/exchange contract
- add CI-safe auth-social regression runner: scripts/api/run-auth-social-e2e-pipeline.sh
- add Make target: make test-auth-social-pipeline
- add GitHub Actions workflow for PR/push auth-social pipeline verification

## Verification
- ./scripts/api/run-auth-social-e2e-pipeline.sh
- make test-auth-social-pipeline
- ./gradlew test

Closes #10