### PR TITLE
[Auth] split real-provider OAuth E2E from CI-safe pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for TicketRush API Testing
 
-.PHONY: help test-v1 test-v2 test-v3 test-v4 test-v5 test-v6 test-v7 test-v9 test-k6 test-k6-dashboard test-suite test-auth-social-pipeline test-all setup-perms
+.PHONY: help test-v1 test-v2 test-v3 test-v4 test-v5 test-v6 test-v7 test-v9 test-k6 test-k6-dashboard test-suite test-auth-social-pipeline test-auth-social-real-provider test-all setup-perms
 
 # 기본 명령어 (도움말)
 help:
@@ -18,6 +18,7 @@ help:
 	@echo " make test-k6-dashboard : [perf] k6 + 웹 대시보드(5665) 실행"
 	@echo " make test-suite : 변경된 API 스크립트 실행 + 리포트 생성"
 	@echo " make test-auth-social-pipeline : auth-social CI-safe 파이프라인 테스트"
+	@echo " make test-auth-social-real-provider : auth-social real provider E2E (선택 실행)"
 	@echo " make test-all   : 모든 버전 순차 테스트"
 	@echo " make setup      : 스크립트 실행 권한 부여"
 	@echo "========================================================================"
@@ -62,6 +63,9 @@ test-suite:
 
 test-auth-social-pipeline:
 	bash ./scripts/api/run-auth-social-e2e-pipeline.sh
+
+test-auth-social-real-provider:
+	bash ./scripts/api/run-auth-social-real-provider-e2e.sh
 
 # 실행 권한 부여
 setup:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ make test-k6
 make test-auth-social-pipeline
 ```
 
+### 6. Auth-Social Real Provider E2E 테스트 (선택)
+```bash
+APP_AUTH_SOCIAL_REAL_E2E_ENABLED=true \
+AUTH_REAL_E2E_PROVIDER=kakao \
+AUTH_REAL_E2E_PREPARE_ONLY=true \
+make test-auth-social-real-provider
+```
+
+- 준비 단계(`AUTH_REAL_E2E_PREPARE_ONLY=true`)에서 authorize URL을 발급하고 브라우저 로그인 후 callback `code`를 획득한다.
+- 실제 검증 단계는 `AUTH_REAL_E2E_CODE=<callback-code>`(네이버는 `AUTH_REAL_E2E_STATE` 포함)로 재실행한다.
 - 로컬 `k6`가 없으면 Docker(`grafana/k6`) fallback으로 자동 실행됩니다.
 - 웹 대시보드 포함 실행: `make test-k6-dashboard` (기본 URL: `http://127.0.0.1:5665`)
 
@@ -64,6 +74,7 @@ make test-auth-social-pipeline
 
 - API 스크립트 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/latest.md`
 - auth-social 파이프라인 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/auth-social-e2e-latest.md`
+- auth-social real provider e2e 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/auth-social-real-provider-e2e-latest.md`
 - k6 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/k6/latest/k6-latest.md`
 - 실시간 푸시 모드 스위치: `APP_PUSH_MODE=sse|websocket` (기본값 `sse`)
 - WebSocket STOMP 엔드포인트: `/ws` (`/topic/waiting-queue/{concertId}/{userId}`, `/topic/reservations/{seatId}/{userId}`)

--- a/scripts/api/run-auth-social-real-provider-e2e.sh
+++ b/scripts/api/run-auth-social-real-provider-e2e.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_abs="$(cd "$script_dir/../.." && pwd)"
+repo_root="$(git -C "$project_abs" rev-parse --show-toplevel)"
+if [[ "$project_abs" == "$repo_root" ]]; then
+  project_root="."
+else
+  project_root="${project_abs#$repo_root/}"
+fi
+
+report_path="${project_root}/.codex/tmp/ticket-core-service/api-test/auth-social-real-provider-e2e-latest.md"
+report_abs_path="${project_abs}/.codex/tmp/ticket-core-service/api-test/auth-social-real-provider-e2e-latest.md"
+tmp_log="$(mktemp)"
+trap 'rm -f "$tmp_log"' EXIT
+
+API_HOST="${API_HOST:-http://127.0.0.1:8080}"
+PROVIDER="${AUTH_REAL_E2E_PROVIDER:-kakao}"
+AUTH_CODE="${AUTH_REAL_E2E_CODE:-}"
+AUTH_STATE="${AUTH_REAL_E2E_STATE:-}"
+PREPARE_ONLY="${AUTH_REAL_E2E_PREPARE_ONLY:-false}"
+REAL_E2E_ENABLED="${APP_AUTH_SOCIAL_REAL_E2E_ENABLED:-false}"
+
+mkdir -p "$(dirname "$report_abs_path")"
+
+log() {
+  echo "$1" | tee -a "$tmp_log" >/dev/null
+}
+
+write_report() {
+  local result="$1"
+  local note="$2"
+
+  cat >"$report_abs_path" <<EOF
+# Auth Social Real Provider E2E Report
+
+- Result: ${result}
+- API Host: \`${API_HOST}\`
+- Provider: \`${PROVIDER}\`
+- Real E2E Enabled: \`${REAL_E2E_ENABLED}\`
+- Prepare Only: \`${PREPARE_ONLY}\`
+- Note: ${note}
+
+## Logs
+\`\`\`text
+$(cat "$tmp_log")
+\`\`\`
+EOF
+}
+
+fail() {
+  local message="$1"
+  log "[FAIL] ${message}"
+  write_report "FAIL" "${message}"
+  echo "[auth-social-real-provider-e2e] failed"
+  echo "[auth-social-real-provider-e2e] report: ${report_path}"
+  exit 1
+}
+
+require_json_field() {
+  local json_payload="$1"
+  local key="$2"
+  python3 - "$json_payload" "$key" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+key = sys.argv[2]
+value = payload.get(key)
+if value is None:
+    raise SystemExit(1)
+print(value)
+PY
+}
+
+extract_authorize_info() {
+  local url="$1"
+  python3 - "$url" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+print(payload.get("authorizeUrl", ""))
+print(payload.get("state", ""))
+PY
+}
+
+build_exchange_payload() {
+  python3 - "$PROVIDER" "$AUTH_CODE" "$AUTH_STATE" <<'PY'
+import json
+import sys
+
+provider = sys.argv[1].lower().strip()
+code = sys.argv[2]
+state = sys.argv[3]
+
+payload = {"code": code}
+if provider == "naver":
+    payload["state"] = state
+elif state:
+    payload["state"] = state
+
+print(json.dumps(payload))
+PY
+}
+
+if [[ "$PROVIDER" != "kakao" && "$PROVIDER" != "naver" ]]; then
+  fail "AUTH_REAL_E2E_PROVIDER must be one of kakao|naver (actual: ${PROVIDER})"
+fi
+
+if [[ "$REAL_E2E_ENABLED" != "true" ]]; then
+  fail "Set APP_AUTH_SOCIAL_REAL_E2E_ENABLED=true before running real-provider e2e."
+fi
+
+if [[ "$PROVIDER" == "naver" && -z "$AUTH_STATE" ]]; then
+  AUTH_STATE="real-e2e-naver-$(date +%s)"
+  log "[INFO] AUTH_REAL_E2E_STATE was empty. Generated state: ${AUTH_STATE}"
+fi
+
+AUTH_URL_PATH="/api/auth/social/${PROVIDER}/authorize-url"
+if [[ -n "$AUTH_STATE" ]]; then
+  AUTH_URL_PATH="${AUTH_URL_PATH}?state=${AUTH_STATE}"
+fi
+
+log "[STEP] Request authorize-url: ${API_HOST}${AUTH_URL_PATH}"
+AUTHORIZE_RAW="$(curl -s -w $'\n%{http_code}' "${API_HOST}${AUTH_URL_PATH}")" || fail "authorize-url request failed"
+AUTHORIZE_BODY="$(echo "$AUTHORIZE_RAW" | sed '$d')"
+AUTHORIZE_CODE="$(echo "$AUTHORIZE_RAW" | tail -n 1)"
+if [[ "$AUTHORIZE_CODE" != "200" ]]; then
+  fail "authorize-url failed (code=${AUTHORIZE_CODE}, body=${AUTHORIZE_BODY})"
+fi
+
+AUTHORIZE_URL="$(extract_authorize_info "$AUTHORIZE_BODY" | sed -n '1p')"
+AUTHORIZE_STATE="$(extract_authorize_info "$AUTHORIZE_BODY" | sed -n '2p')"
+if [[ -n "$AUTHORIZE_STATE" ]]; then
+  AUTH_STATE="$AUTHORIZE_STATE"
+fi
+log "[INFO] provider authorize url ready"
+log "[INFO] open this URL in browser and complete login:"
+log "${AUTHORIZE_URL}"
+log "[INFO] expected state: ${AUTH_STATE}"
+
+if [[ "$PREPARE_ONLY" == "true" ]]; then
+  write_report "PREPARED" "Authorize URL generated. Use callback code and rerun with AUTH_REAL_E2E_CODE."
+  echo "[auth-social-real-provider-e2e] prepared"
+  echo "[auth-social-real-provider-e2e] report: ${report_path}"
+  exit 0
+fi
+
+if [[ -z "$AUTH_CODE" ]]; then
+  fail "AUTH_REAL_E2E_CODE is required. Re-run with callback code."
+fi
+
+EXCHANGE_PAYLOAD="$(build_exchange_payload)"
+log "[STEP] Exchange social code (${PROVIDER})"
+EXCHANGE_RAW="$(curl -s -w $'\n%{http_code}' -X POST "${API_HOST}/api/auth/social/${PROVIDER}/exchange" \
+  -H "Content-Type: application/json" \
+  -d "${EXCHANGE_PAYLOAD}")" || fail "social exchange request failed"
+EXCHANGE_BODY="$(echo "$EXCHANGE_RAW" | sed '$d')"
+EXCHANGE_CODE="$(echo "$EXCHANGE_RAW" | tail -n 1)"
+if [[ "$EXCHANGE_CODE" != "200" ]]; then
+  fail "social exchange failed (code=${EXCHANGE_CODE}, body=${EXCHANGE_BODY})"
+fi
+
+ACCESS_TOKEN="$(require_json_field "$EXCHANGE_BODY" "accessToken")" || fail "accessToken missing in exchange response"
+REFRESH_TOKEN="$(require_json_field "$EXCHANGE_BODY" "refreshToken")" || fail "refreshToken missing in exchange response"
+USER_ID="$(require_json_field "$EXCHANGE_BODY" "userId")" || fail "userId missing in exchange response"
+log "[INFO] social exchange success (userId=${USER_ID}, accessLen=${#ACCESS_TOKEN}, refreshLen=${#REFRESH_TOKEN})"
+
+log "[STEP] Verify /api/auth/me with issued access token"
+ME_RAW="$(curl -s -w $'\n%{http_code}' -X GET "${API_HOST}/api/auth/me" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}")" || fail "/api/auth/me request failed"
+ME_BODY="$(echo "$ME_RAW" | sed '$d')"
+ME_CODE="$(echo "$ME_RAW" | tail -n 1)"
+if [[ "$ME_CODE" != "200" ]]; then
+  fail "/api/auth/me failed (code=${ME_CODE}, body=${ME_BODY})"
+fi
+log "[INFO] /api/auth/me success"
+
+log "[STEP] Logout with issued refresh/access tokens"
+LOGOUT_RAW="$(curl -s -w $'\n%{http_code}' -X POST "${API_HOST}/api/auth/logout" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")" || fail "/api/auth/logout request failed"
+LOGOUT_BODY="$(echo "$LOGOUT_RAW" | sed '$d')"
+LOGOUT_CODE="$(echo "$LOGOUT_RAW" | tail -n 1)"
+if [[ "$LOGOUT_CODE" != "200" ]]; then
+  fail "/api/auth/logout failed (code=${LOGOUT_CODE}, body=${LOGOUT_BODY})"
+fi
+log "[INFO] logout success"
+
+log "[STEP] Verify revoked access token is blocked"
+REUSED_ME_RAW="$(curl -s -w $'\n%{http_code}' -X GET "${API_HOST}/api/auth/me" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}")" || fail "reused /api/auth/me request failed"
+REUSED_ME_BODY="$(echo "$REUSED_ME_RAW" | sed '$d')"
+REUSED_ME_CODE="$(echo "$REUSED_ME_RAW" | tail -n 1)"
+REUSED_ME_ERROR_CODE="$(python3 - "$REUSED_ME_BODY" <<'PY'
+import json
+import sys
+try:
+    payload = json.loads(sys.argv[1])
+except Exception:
+    payload = {}
+print(payload.get("errorCode", ""))
+PY
+)"
+if [[ "$REUSED_ME_CODE" != "401" || "$REUSED_ME_ERROR_CODE" != "AUTH_ACCESS_TOKEN_REVOKED" ]]; then
+  fail "reused access token guard failed (code=${REUSED_ME_CODE}, errorCode=${REUSED_ME_ERROR_CODE}, body=${REUSED_ME_BODY})"
+fi
+log "[INFO] revoked access token guard success"
+
+log "[STEP] Verify revoked refresh token is blocked"
+REUSED_REFRESH_RAW="$(curl -s -w $'\n%{http_code}' -X POST "${API_HOST}/api/auth/token/refresh" \
+  -H "Content-Type: application/json" \
+  -d "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")" || fail "reused refresh request failed"
+REUSED_REFRESH_BODY="$(echo "$REUSED_REFRESH_RAW" | sed '$d')"
+REUSED_REFRESH_CODE="$(echo "$REUSED_REFRESH_RAW" | tail -n 1)"
+REUSED_REFRESH_ERROR_CODE="$(python3 - "$REUSED_REFRESH_BODY" <<'PY'
+import json
+import sys
+try:
+    payload = json.loads(sys.argv[1])
+except Exception:
+    payload = {}
+print(payload.get("errorCode", ""))
+PY
+)"
+if [[ "$REUSED_REFRESH_CODE" != "400" || "$REUSED_REFRESH_ERROR_CODE" != "AUTH_REFRESH_TOKEN_EXPIRED_OR_REVOKED" ]]; then
+  fail "reused refresh token guard failed (code=${REUSED_REFRESH_CODE}, errorCode=${REUSED_REFRESH_ERROR_CODE}, body=${REUSED_REFRESH_BODY})"
+fi
+log "[INFO] revoked refresh token guard success"
+
+write_report "PASS" "Real provider e2e completed successfully."
+echo "[auth-social-real-provider-e2e] passed"
+echo "[auth-social-real-provider-e2e] report: ${report_path}"

--- a/src/main/java/com/ticketrush/global/config/SocialLoginProperties.java
+++ b/src/main/java/com/ticketrush/global/config/SocialLoginProperties.java
@@ -13,6 +13,7 @@ public class SocialLoginProperties {
 
     private Provider kakao = new Provider();
     private Provider naver = new Provider();
+    private RealE2e realE2e = new RealE2e();
 
     @Getter
     @Setter
@@ -21,5 +22,11 @@ public class SocialLoginProperties {
         private String clientSecret;
         private String redirectUri;
         private String serviceUrl;
+    }
+
+    @Getter
+    @Setter
+    public static class RealE2e {
+        private boolean enabled = false;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,9 @@ app:
       access-token-seconds: ${AUTH_ACCESS_TOKEN_SECONDS:1800}
       refresh-token-seconds: ${AUTH_REFRESH_TOKEN_SECONDS:1209600}
       access-token-blocklist-key-prefix: ${AUTH_ACCESS_TOKEN_BLOCKLIST_KEY_PREFIX:auth:access-blocklist:}
+  social:
+    real-e2e:
+      enabled: ${APP_AUTH_SOCIAL_REAL_E2E_ENABLED:false}
   frontend:
     u1-callback-url: ${U1_CALLBACK_URL:/ux/u1/callback.html}
     allowed-origins: ${FRONTEND_ALLOWED_ORIGINS:http://localhost:8080,http://127.0.0.1:8080}


### PR DESCRIPTION
## Summary
- 외부 OAuth real provider E2E를 CI-safe 파이프라인과 분리한 선택 실행 경로를 추가
- `application.yml`에 real-e2e enable 설정값(`APP_AUTH_SOCIAL_REAL_E2E_ENABLED`)을 추가
- Make/README에서 준비 단계(인가 URL 발급)와 실행 단계(실코드 검증)를 명시

## Changes
- `scripts/api/run-auth-social-real-provider-e2e.sh` 신규
  - prepare-only 모드로 authorize-url 발급
  - callback `code` 입력 후 exchange/me/logout/reuse-guard를 end-to-end 검증
  - 리포트: `.codex/tmp/ticket-core-service/api-test/auth-social-real-provider-e2e-latest.md`
- `Makefile`
  - `test-auth-social-real-provider` 타깃 추가
- `README.md`
  - real provider 선택 실행 절차/환경변수 추가
- `application.yml`
  - `app.social.real-e2e.enabled=${APP_AUTH_SOCIAL_REAL_E2E_ENABLED:false}` 추가
- `SocialLoginProperties`
  - `realE2e.enabled` 바인딩 필드 추가

## Verification
- `bash -n scripts/api/run-auth-social-real-provider-e2e.sh`
- `./gradlew test --tests com.ticketrush.api.controller.SocialAuthControllerIntegrationTest --tests com.ticketrush.domain.auth.service.SocialAuthServiceTest`
- `./scripts/api/run-auth-social-real-provider-e2e.sh` (flag 미설정 시 fail-fast 확인)

Closes #10
