### PR TITLE
feat(payment): webhook-driven pg-ready transitions and admin refund audits

### DIFF
--- a/src/main/java/com/ticketrush/api/dto/reservation/AdminRefundAuditResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/reservation/AdminRefundAuditResponse.java
@@ -1,0 +1,36 @@
+package com.ticketrush.api.dto.reservation;
+
+import com.ticketrush.domain.reservation.entity.AdminRefundAuditLog;
+import com.ticketrush.domain.user.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminRefundAuditResponse {
+    private Long id;
+    private Long reservationId;
+    private Long targetUserId;
+    private Long actorUserId;
+    private UserRole actorRole;
+    private AdminRefundAuditLog.AuditResult result;
+    private String detailMessage;
+    private LocalDateTime occurredAt;
+
+    public static AdminRefundAuditResponse from(AdminRefundAuditLog auditLog) {
+        return new AdminRefundAuditResponse(
+                auditLog.getId(),
+                auditLog.getReservationId(),
+                auditLog.getTargetUserId(),
+                auditLog.getActorUserId(),
+                auditLog.getActorRole(),
+                auditLog.getResult(),
+                auditLog.getDetailMessage(),
+                auditLog.getOccurredAt()
+        );
+    }
+}

--- a/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransaction.java
+++ b/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransaction.java
@@ -97,11 +97,31 @@ public class PaymentTransaction {
             String idempotencyKey,
             String description
     ) {
+        return payment(
+                user,
+                reservationId,
+                amount,
+                balanceAfterAmount,
+                idempotencyKey,
+                description,
+                PaymentTransactionStatus.SUCCESS
+        );
+    }
+
+    public static PaymentTransaction payment(
+            User user,
+            Long reservationId,
+            Long amount,
+            Long balanceAfterAmount,
+            String idempotencyKey,
+            String description,
+            PaymentTransactionStatus status
+    ) {
         return new PaymentTransaction(
                 user,
                 reservationId,
                 PaymentTransactionType.PAYMENT,
-                PaymentTransactionStatus.SUCCESS,
+                status,
                 amount,
                 balanceAfterAmount,
                 idempotencyKey,
@@ -146,6 +166,20 @@ public class PaymentTransaction {
         this.amount = amount;
         this.balanceAfterAmount = balanceAfterAmount;
         this.idempotencyKey = idempotencyKey;
+        this.description = description;
+    }
+
+    public boolean isStatus(PaymentTransactionStatus expectedStatus) {
+        return this.status == expectedStatus;
+    }
+
+    public void markSuccess(String description) {
+        this.status = PaymentTransactionStatus.SUCCESS;
+        this.description = description;
+    }
+
+    public void markFailed(String description) {
+        this.status = PaymentTransactionStatus.FAILED;
         this.description = description;
     }
 

--- a/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransactionStatus.java
+++ b/src/main/java/com/ticketrush/domain/payment/entity/PaymentTransactionStatus.java
@@ -1,5 +1,7 @@
 package com.ticketrush.domain.payment.entity;
 
 public enum PaymentTransactionStatus {
-    SUCCESS
+    PENDING,
+    SUCCESS,
+    FAILED
 }

--- a/src/main/java/com/ticketrush/domain/payment/gateway/PgReadyPaymentGateway.java
+++ b/src/main/java/com/ticketrush/domain/payment/gateway/PgReadyPaymentGateway.java
@@ -32,14 +32,15 @@ public class PgReadyPaymentGateway implements PaymentGateway {
         long normalizedAmount = validatePositiveAmount(amount);
         User user = getUser(userId);
 
-        // PG 연동 전환 전까지는 승인 이벤트를 즉시 성공으로 시뮬레이션한다.
+        // 외부 PG 승인 webhook 확정 전에는 PENDING 상태로 저장한다.
         return paymentTransactionRepository.save(PaymentTransaction.payment(
                 user,
                 reservationId,
                 normalizedAmount,
                 user.getWalletBalanceAmountSafe(),
                 key,
-                "PG_READY_PAYMENT_APPROVED"
+                "PG_READY_PAYMENT_PENDING",
+                PaymentTransactionStatus.PENDING
         ));
     }
 

--- a/src/main/java/com/ticketrush/domain/payment/repository/PaymentTransactionRepository.java
+++ b/src/main/java/com/ticketrush/domain/payment/repository/PaymentTransactionRepository.java
@@ -19,5 +19,10 @@ public interface PaymentTransactionRepository extends JpaRepository<PaymentTrans
             PaymentTransactionStatus status
     );
 
+    Optional<PaymentTransaction> findTopByReservationIdAndTypeOrderByIdDesc(
+            Long reservationId,
+            PaymentTransactionType type
+    );
+
     List<PaymentTransaction> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/ticketrush/domain/payment/webhook/PgReadyWebhookService.java
+++ b/src/main/java/com/ticketrush/domain/payment/webhook/PgReadyWebhookService.java
@@ -2,18 +2,42 @@ package com.ticketrush.domain.payment.webhook;
 
 import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
 import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
+import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import com.ticketrush.domain.payment.repository.PaymentTransactionRepository;
+import com.ticketrush.domain.reservation.entity.Reservation;
+import com.ticketrush.domain.reservation.repository.ReservationRepository;
+import com.ticketrush.global.cache.ConcertReadCacheEvictor;
+import com.ticketrush.global.push.PushNotifier;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class PgReadyWebhookService {
 
+    private final PaymentTransactionRepository paymentTransactionRepository;
+    private final ReservationRepository reservationRepository;
+    private final PushNotifier pushNotifier;
+    private final ConcertReadCacheEvictor concertReadCacheEvictor;
+
+    private static final String EVENT_PAYMENT = "PAYMENT";
+    private static final String STATUS_APPROVED = "APPROVED";
+    private static final String STATUS_FAILED = "FAILED";
+
+    @Transactional
     public PgReadyWebhookResponse handle(PgReadyWebhookRequest request) {
-        String eventType = normalize(request.getEventType());
-        String status = normalize(request.getStatus());
+        String eventType = normalizeUpper(request.getEventType());
+        String status = normalizeUpper(request.getStatus());
         Long reservationId = request.getReservationId();
+        String providerEventId = normalizeRaw(request.getProviderEventId());
 
         if (!StringUtils.hasText(eventType)) {
             throw new IllegalArgumentException("eventType is required");
@@ -25,26 +49,104 @@ public class PgReadyWebhookService {
             throw new IllegalArgumentException("reservationId is required");
         }
 
-        // Webhook 계약만 먼저 고정하고, 실제 결제승인 상태전이는 후속 task에서 연결한다.
+        if (!EVENT_PAYMENT.equals(eventType)) {
+            return acceptedResponse(eventType, status, reservationId, "ignored unsupported eventType");
+        }
+
+        PaymentTransaction paymentTransaction = resolvePaymentTransaction(request, reservationId);
+        if (STATUS_APPROVED.equals(status)) {
+            handleApproved(paymentTransaction, reservationId, providerEventId);
+            return acceptedResponse(eventType, status, reservationId, "applied approved");
+        }
+        if (STATUS_FAILED.equals(status)) {
+            handleFailed(paymentTransaction, providerEventId);
+            return acceptedResponse(eventType, status, reservationId, "applied failed");
+        }
+
         log.info(
-                ">>>> [PgReadyWebhook] accepted eventType={}, status={}, reservationId={}, providerEventId={}",
+                ">>>> [PgReadyWebhook] ignored unsupported status eventType={}, status={}, reservationId={}, providerEventId={}",
                 eventType,
                 status,
                 reservationId,
-                normalize(request.getProviderEventId())
+                providerEventId
         );
 
-        return new PgReadyWebhookResponse(
-                "pg-ready",
-                eventType,
-                status,
+        return acceptedResponse(eventType, status, reservationId, "ignored unsupported status");
+    }
+
+    private PaymentTransaction resolvePaymentTransaction(PgReadyWebhookRequest request, Long reservationId) {
+        String idempotencyKey = normalizeRaw(request.getIdempotencyKey());
+        if (StringUtils.hasText(idempotencyKey)) {
+            return paymentTransactionRepository.findByIdempotencyKey(idempotencyKey)
+                    .orElseThrow(() -> new IllegalStateException("Payment transaction not found. idempotencyKey=" + idempotencyKey));
+        }
+        return paymentTransactionRepository
+                .findTopByReservationIdAndTypeOrderByIdDesc(reservationId, PaymentTransactionType.PAYMENT)
+                .orElseThrow(() -> new IllegalStateException("Payment transaction not found for reservation: " + reservationId));
+    }
+
+    private void handleApproved(PaymentTransaction paymentTransaction, Long reservationId, String providerEventId) {
+        if (paymentTransaction.isStatus(PaymentTransactionStatus.SUCCESS)) {
+            log.info(
+                    ">>>> [PgReadyWebhook] already approved reservationId={}, txId={}",
+                    reservationId,
+                    paymentTransaction.getId()
+            );
+            return;
+        }
+
+        paymentTransaction.markSuccess(buildDescription("PG_READY_PAYMENT_APPROVED", providerEventId));
+
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalStateException("Reservation not found. reservationId=" + reservationId));
+
+        if (reservation.getStatus() == Reservation.ReservationStatus.PAYING) {
+            LocalDateTime now = LocalDateTime.now();
+            reservation.confirmPayment(now);
+            reservation.getSeat().confirmHeldSeat();
+            concertReadCacheEvictor.evictAvailableSeatsByOptionId(reservation.getSeat().getConcertOption().getId());
+            pushNotifier.sendReservationStatus(
+                    reservation.getUser().getId(),
+                    reservation.getSeat().getId(),
+                    Reservation.ReservationStatus.CONFIRMED.name()
+            );
+            return;
+        }
+
+        log.warn(
+                ">>>> [PgReadyWebhook] approved but reservation not PAYING. reservationId={}, reservationStatus={}, txId={}",
                 reservationId,
-                true,
-                "accepted"
+                reservation.getStatus(),
+                paymentTransaction.getId()
         );
     }
 
-    private String normalize(String value) {
+    private void handleFailed(PaymentTransaction paymentTransaction, String providerEventId) {
+        if (paymentTransaction.isStatus(PaymentTransactionStatus.FAILED)) {
+            return;
+        }
+        paymentTransaction.markFailed(buildDescription("PG_READY_PAYMENT_FAILED", providerEventId));
+    }
+
+    private PgReadyWebhookResponse acceptedResponse(String eventType, String status, Long reservationId, String message) {
+        return new PgReadyWebhookResponse("pg-ready", eventType, status, reservationId, true, message);
+    }
+
+    private String buildDescription(String base, String providerEventId) {
+        if (!StringUtils.hasText(providerEventId)) {
+            return base;
+        }
+        return base + ":" + providerEventId;
+    }
+
+    private String normalizeUpper(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        return value.trim().toUpperCase();
+    }
+
+    private String normalizeRaw(String value) {
         if (!StringUtils.hasText(value)) {
             return "";
         }

--- a/src/main/java/com/ticketrush/domain/reservation/adapter/outbound/ReservationPaymentPortAdapter.java
+++ b/src/main/java/com/ticketrush/domain/reservation/adapter/outbound/ReservationPaymentPortAdapter.java
@@ -1,5 +1,6 @@
 package com.ticketrush.domain.reservation.adapter.outbound;
 
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.gateway.PaymentGateway;
 import com.ticketrush.domain.reservation.port.outbound.ReservationPaymentPort;
 import lombok.RequiredArgsConstructor;
@@ -14,13 +15,13 @@ public class ReservationPaymentPortAdapter implements ReservationPaymentPort {
 
     @Override
     @Transactional
-    public void payForReservation(Long userId, Long reservationId, Long amount, String idempotencyKey) {
-        paymentGateway.payForReservation(userId, reservationId, amount, idempotencyKey);
+    public PaymentTransaction payForReservation(Long userId, Long reservationId, Long amount, String idempotencyKey) {
+        return paymentGateway.payForReservation(userId, reservationId, amount, idempotencyKey);
     }
 
     @Override
     @Transactional
-    public void refundReservation(Long userId, Long reservationId, String idempotencyKey) {
-        paymentGateway.refundReservation(userId, reservationId, idempotencyKey);
+    public PaymentTransaction refundReservation(Long userId, Long reservationId, String idempotencyKey) {
+        return paymentGateway.refundReservation(userId, reservationId, idempotencyKey);
     }
 }

--- a/src/main/java/com/ticketrush/domain/reservation/entity/AdminRefundAuditLog.java
+++ b/src/main/java/com/ticketrush/domain/reservation/entity/AdminRefundAuditLog.java
@@ -1,0 +1,148 @@
+package com.ticketrush.domain.reservation.entity;
+
+import com.ticketrush.domain.user.UserRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "admin_refund_audit_logs",
+        indexes = {
+                @Index(name = "idx_admin_refund_reservation_time", columnList = "reservationId, occurredAt"),
+                @Index(name = "idx_admin_refund_actor_time", columnList = "actorUserId, occurredAt")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminRefundAuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long reservationId;
+
+    private Long targetUserId;
+
+    @Column(nullable = false)
+    private Long actorUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole actorRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AuditResult result;
+
+    @Column(length = 400)
+    private String detailMessage;
+
+    @Column(nullable = false)
+    private LocalDateTime occurredAt;
+
+    private AdminRefundAuditLog(
+            Long reservationId,
+            Long targetUserId,
+            Long actorUserId,
+            UserRole actorRole,
+            AuditResult result,
+            String detailMessage,
+            LocalDateTime occurredAt
+    ) {
+        this.reservationId = reservationId;
+        this.targetUserId = targetUserId;
+        this.actorUserId = actorUserId;
+        this.actorRole = actorRole;
+        this.result = result;
+        this.detailMessage = normalizeDetail(detailMessage);
+        this.occurredAt = occurredAt;
+    }
+
+    public static AdminRefundAuditLog success(
+            Long reservationId,
+            Long targetUserId,
+            Long actorUserId,
+            UserRole actorRole,
+            String detailMessage
+    ) {
+        return new AdminRefundAuditLog(
+                reservationId,
+                targetUserId,
+                actorUserId,
+                actorRole,
+                AuditResult.SUCCESS,
+                detailMessage,
+                LocalDateTime.now()
+        );
+    }
+
+    public static AdminRefundAuditLog denied(
+            Long reservationId,
+            Long targetUserId,
+            Long actorUserId,
+            UserRole actorRole,
+            String detailMessage
+    ) {
+        return new AdminRefundAuditLog(
+                reservationId,
+                targetUserId,
+                actorUserId,
+                actorRole,
+                AuditResult.DENIED,
+                detailMessage,
+                LocalDateTime.now()
+        );
+    }
+
+    public static AdminRefundAuditLog failed(
+            Long reservationId,
+            Long targetUserId,
+            Long actorUserId,
+            UserRole actorRole,
+            String detailMessage
+    ) {
+        return new AdminRefundAuditLog(
+                reservationId,
+                targetUserId,
+                actorUserId,
+                actorRole,
+                AuditResult.FAILED,
+                detailMessage,
+                LocalDateTime.now()
+        );
+    }
+
+    private static String normalizeDetail(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if (trimmed.length() <= 400) {
+            return trimmed;
+        }
+        return trimmed.substring(0, 400);
+    }
+
+    public enum AuditResult {
+        SUCCESS,
+        DENIED,
+        FAILED
+    }
+}

--- a/src/main/java/com/ticketrush/domain/reservation/port/outbound/ReservationPaymentPort.java
+++ b/src/main/java/com/ticketrush/domain/reservation/port/outbound/ReservationPaymentPort.java
@@ -1,8 +1,10 @@
 package com.ticketrush.domain.reservation.port.outbound;
 
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+
 public interface ReservationPaymentPort {
 
-    void payForReservation(Long userId, Long reservationId, Long amount, String idempotencyKey);
+    PaymentTransaction payForReservation(Long userId, Long reservationId, Long amount, String idempotencyKey);
 
-    void refundReservation(Long userId, Long reservationId, String idempotencyKey);
+    PaymentTransaction refundReservation(Long userId, Long reservationId, String idempotencyKey);
 }

--- a/src/main/java/com/ticketrush/domain/reservation/repository/AdminRefundAuditLogRepository.java
+++ b/src/main/java/com/ticketrush/domain/reservation/repository/AdminRefundAuditLogRepository.java
@@ -1,0 +1,32 @@
+package com.ticketrush.domain.reservation.repository;
+
+import com.ticketrush.domain.reservation.entity.AdminRefundAuditLog;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AdminRefundAuditLogRepository extends JpaRepository<AdminRefundAuditLog, Long> {
+
+    @Query("""
+            select l
+            from AdminRefundAuditLog l
+            where (:reservationId is null or l.reservationId = :reservationId)
+              and (:actorUserId is null or l.actorUserId = :actorUserId)
+              and (:result is null or l.result = :result)
+              and l.occurredAt >= coalesce(:fromAt, l.occurredAt)
+              and l.occurredAt <= coalesce(:toAt, l.occurredAt)
+            order by l.occurredAt desc, l.id desc
+            """)
+    List<AdminRefundAuditLog> search(
+            @Param("reservationId") Long reservationId,
+            @Param("actorUserId") Long actorUserId,
+            @Param("result") AdminRefundAuditLog.AuditResult result,
+            @Param("fromAt") LocalDateTime fromAt,
+            @Param("toAt") LocalDateTime toAt,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/ticketrush/domain/reservation/service/AdminRefundAuditService.java
+++ b/src/main/java/com/ticketrush/domain/reservation/service/AdminRefundAuditService.java
@@ -1,0 +1,85 @@
+package com.ticketrush.domain.reservation.service;
+
+import com.ticketrush.domain.reservation.entity.AdminRefundAuditLog;
+import com.ticketrush.domain.reservation.repository.AdminRefundAuditLogRepository;
+import com.ticketrush.domain.user.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminRefundAuditService {
+
+    private final AdminRefundAuditLogRepository adminRefundAuditLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordSuccess(
+            Long reservationId,
+            Long targetUserId,
+            Long actorUserId,
+            UserRole actorRole,
+            String detailMessage
+    ) {
+        adminRefundAuditLogRepository.save(
+                AdminRefundAuditLog.success(reservationId, targetUserId, actorUserId, actorRole, detailMessage)
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordDenied(
+            Long reservationId,
+            Long targetUserId,
+            Long actorUserId,
+            UserRole actorRole,
+            String detailMessage
+    ) {
+        adminRefundAuditLogRepository.save(
+                AdminRefundAuditLog.denied(reservationId, targetUserId, actorUserId, actorRole, detailMessage)
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordFailed(
+            Long reservationId,
+            Long targetUserId,
+            Long actorUserId,
+            UserRole actorRole,
+            String detailMessage
+    ) {
+        adminRefundAuditLogRepository.save(
+                AdminRefundAuditLog.failed(reservationId, targetUserId, actorUserId, actorRole, detailMessage)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminRefundAuditLog> getAuditLogs(
+            Long reservationId,
+            Long actorUserId,
+            AdminRefundAuditLog.AuditResult result,
+            LocalDateTime fromAt,
+            LocalDateTime toAt,
+            Integer limit
+    ) {
+        return adminRefundAuditLogRepository.search(
+                reservationId,
+                actorUserId,
+                result,
+                fromAt,
+                toAt,
+                PageRequest.of(0, normalizeLimit(limit))
+        );
+    }
+
+    private int normalizeLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return 50;
+        }
+        return Math.min(limit, 200);
+    }
+}

--- a/src/test/java/com/ticketrush/domain/payment/gateway/PgReadyPaymentGatewayIntegrationTest.java
+++ b/src/test/java/com/ticketrush/domain/payment/gateway/PgReadyPaymentGatewayIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.domain.payment.gateway;
 
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
+import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
 import com.ticketrush.domain.payment.entity.PaymentTransactionType;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;
@@ -23,7 +24,7 @@ class PgReadyPaymentGatewayIntegrationTest {
     private UserRepository userRepository;
 
     @Test
-    void payForReservation_shouldCreateApprovedPaymentTransaction() {
+    void payForReservation_shouldCreatePendingPaymentTransaction() {
         User user = userRepository.save(new User("pg-ready-user-" + System.nanoTime()));
 
         PaymentTransaction tx = paymentGateway.payForReservation(
@@ -34,7 +35,8 @@ class PgReadyPaymentGatewayIntegrationTest {
         );
 
         assertThat(tx.getType()).isEqualTo(PaymentTransactionType.PAYMENT);
-        assertThat(tx.getDescription()).isEqualTo("PG_READY_PAYMENT_APPROVED");
+        assertThat(tx.getStatus()).isEqualTo(PaymentTransactionStatus.PENDING);
+        assertThat(tx.getDescription()).isEqualTo("PG_READY_PAYMENT_PENDING");
         assertThat(tx.getBalanceAfterAmount()).isEqualTo(user.getWalletBalanceAmountSafe());
     }
 }

--- a/src/test/java/com/ticketrush/domain/payment/webhook/PgReadyWebhookServiceTest.java
+++ b/src/test/java/com/ticketrush/domain/payment/webhook/PgReadyWebhookServiceTest.java
@@ -2,49 +2,206 @@ package com.ticketrush.domain.payment.webhook;
 
 import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
 import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;
+import com.ticketrush.domain.agency.Agency;
+import com.ticketrush.domain.agency.AgencyRepository;
+import com.ticketrush.domain.artist.Artist;
+import com.ticketrush.domain.artist.ArtistRepository;
+import com.ticketrush.domain.concert.entity.Concert;
+import com.ticketrush.domain.concert.entity.ConcertOption;
+import com.ticketrush.domain.concert.entity.Seat;
+import com.ticketrush.domain.concert.repository.ConcertOptionRepository;
+import com.ticketrush.domain.concert.repository.ConcertRepository;
+import com.ticketrush.domain.concert.repository.SeatRepository;
+import com.ticketrush.domain.payment.entity.PaymentTransaction;
+import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
+import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import com.ticketrush.domain.payment.repository.PaymentTransactionRepository;
+import com.ticketrush.domain.reservation.entity.Reservation;
+import com.ticketrush.domain.reservation.repository.ReservationRepository;
+import com.ticketrush.domain.user.User;
+import com.ticketrush.domain.user.UserRepository;
+import com.ticketrush.global.cache.ConcertReadCacheEvictor;
+import com.ticketrush.global.push.PushNotifier;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+@DataJpaTest
+@Import({PgReadyWebhookService.class, PgReadyWebhookServiceTest.TestConfig.class})
 class PgReadyWebhookServiceTest {
 
-    private final PgReadyWebhookService pgReadyWebhookService = new PgReadyWebhookService();
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        PushNotifier pushNotifier() {
+            return mock(PushNotifier.class);
+        }
+
+        @Bean
+        ConcertReadCacheEvictor concertReadCacheEvictor() {
+            return mock(ConcertReadCacheEvictor.class);
+        }
+    }
+
+    @jakarta.annotation.Resource
+    private PgReadyWebhookService pgReadyWebhookService;
+
+    @jakarta.annotation.Resource
+    private PaymentTransactionRepository paymentTransactionRepository;
+
+    @jakarta.annotation.Resource
+    private ReservationRepository reservationRepository;
+
+    @jakarta.annotation.Resource
+    private SeatRepository seatRepository;
+
+    @jakarta.annotation.Resource
+    private UserRepository userRepository;
+
+    @jakarta.annotation.Resource
+    private AgencyRepository agencyRepository;
+
+    @jakarta.annotation.Resource
+    private ArtistRepository artistRepository;
+
+    @jakarta.annotation.Resource
+    private ConcertRepository concertRepository;
+
+    @jakarta.annotation.Resource
+    private ConcertOptionRepository concertOptionRepository;
+
+    @jakarta.annotation.Resource
+    private PushNotifier pushNotifier;
 
     @Test
-    void handle_shouldAcceptValidWebhookPayload() {
+    void handle_shouldConfirmReservationWhenApproved() {
+        User user = userRepository.save(new User("pg-webhook-approve-user-" + System.nanoTime()));
+        Seat seat = saveSeat("PG-A-101");
+        seat.hold();
+        Reservation reservation = reservationRepository.save(
+                Reservation.hold(user, seat, LocalDateTime.now(), LocalDateTime.now().plusMinutes(5))
+        );
+        reservation.startPaying(LocalDateTime.now());
+        String idempotencyKey = "reservation-payment-" + reservation.getId();
+        PaymentTransaction paymentTransaction = paymentTransactionRepository.save(
+                PaymentTransaction.payment(
+                        user,
+                        reservation.getId(),
+                        100_000L,
+                        user.getWalletBalanceAmountSafe(),
+                        idempotencyKey,
+                        "PG_READY_PAYMENT_PENDING",
+                        PaymentTransactionStatus.PENDING
+                )
+        );
+
         PgReadyWebhookResponse response = pgReadyWebhookService.handle(new PgReadyWebhookRequest(
-                "evt-123",
+                "evt-approved-1",
                 "PAYMENT",
+                "APPROVED",
+                user.getId(),
+                reservation.getId(),
+                100_000L,
+                idempotencyKey,
+                "2026-02-21T05:00:00Z",
+                "sig-abc",
+                null
+        ));
+
+        Reservation updatedReservation = reservationRepository.findById(reservation.getId()).orElseThrow();
+        PaymentTransaction updatedPaymentTransaction = paymentTransactionRepository.findById(paymentTransaction.getId()).orElseThrow();
+        Seat updatedSeat = seatRepository.findById(seat.getId()).orElseThrow();
+
+        assertThat(response.isAccepted()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("applied approved");
+        assertThat(updatedReservation.getStatus()).isEqualTo(Reservation.ReservationStatus.CONFIRMED);
+        assertThat(updatedReservation.getConfirmedAt()).isNotNull();
+        assertThat(updatedSeat.getStatus()).isEqualTo(Seat.SeatStatus.RESERVED);
+        assertThat(updatedPaymentTransaction.getStatus()).isEqualTo(PaymentTransactionStatus.SUCCESS);
+        assertThat(updatedPaymentTransaction.getDescription()).contains("PG_READY_PAYMENT_APPROVED");
+        verify(pushNotifier).sendReservationStatus(user.getId(), seat.getId(), Reservation.ReservationStatus.CONFIRMED.name());
+    }
+
+    @Test
+    void handle_shouldKeepPayingWhenFailed() {
+        User user = userRepository.save(new User("pg-webhook-failed-user-" + System.nanoTime()));
+        Seat seat = saveSeat("PG-A-102");
+        seat.hold();
+        Reservation reservation = reservationRepository.save(
+                Reservation.hold(user, seat, LocalDateTime.now(), LocalDateTime.now().plusMinutes(5))
+        );
+        reservation.startPaying(LocalDateTime.now());
+        String idempotencyKey = "reservation-payment-" + reservation.getId();
+        PaymentTransaction paymentTransaction = paymentTransactionRepository.save(
+                PaymentTransaction.payment(
+                        user,
+                        reservation.getId(),
+                        100_000L,
+                        user.getWalletBalanceAmountSafe(),
+                        idempotencyKey,
+                        "PG_READY_PAYMENT_PENDING",
+                        PaymentTransactionStatus.PENDING
+                )
+        );
+
+        PgReadyWebhookResponse response = pgReadyWebhookService.handle(new PgReadyWebhookRequest(
+                "evt-failed-1",
+                "PAYMENT",
+                "FAILED",
+                user.getId(),
+                reservation.getId(),
+                100_000L,
+                idempotencyKey,
+                "2026-02-21T05:01:00Z",
+                "sig-def",
+                null
+        ));
+
+        Reservation updatedReservation = reservationRepository.findById(reservation.getId()).orElseThrow();
+        PaymentTransaction updatedPaymentTransaction = paymentTransactionRepository.findById(paymentTransaction.getId()).orElseThrow();
+        Seat updatedSeat = seatRepository.findById(seat.getId()).orElseThrow();
+
+        assertThat(response.isAccepted()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("applied failed");
+        assertThat(updatedReservation.getStatus()).isEqualTo(Reservation.ReservationStatus.PAYING);
+        assertThat(updatedReservation.getConfirmedAt()).isNull();
+        assertThat(updatedSeat.getStatus()).isEqualTo(Seat.SeatStatus.TEMP_RESERVED);
+        assertThat(updatedPaymentTransaction.getStatus()).isEqualTo(PaymentTransactionStatus.FAILED);
+        assertThat(updatedPaymentTransaction.getDescription()).contains("PG_READY_PAYMENT_FAILED");
+    }
+
+    @Test
+    void handle_shouldIgnoreUnsupportedEventType() {
+        PgReadyWebhookResponse response = pgReadyWebhookService.handle(new PgReadyWebhookRequest(
+                "evt-unsupported",
+                "REFUND",
                 "APPROVED",
                 1001L,
                 9001L,
                 100_000L,
-                "pg-payment-9001",
+                null,
                 "2026-02-21T05:00:00Z",
                 "sig-abc",
                 null
         ));
 
         assertThat(response.isAccepted()).isTrue();
-        assertThat(response.getProvider()).isEqualTo("pg-ready");
-        assertThat(response.getReservationId()).isEqualTo(9001L);
+        assertThat(response.getMessage()).isEqualTo("ignored unsupported eventType");
     }
 
-    @Test
-    void handle_shouldRejectWhenEventTypeMissing() {
-        assertThatThrownBy(() -> pgReadyWebhookService.handle(new PgReadyWebhookRequest(
-                "evt-123",
-                "",
-                "APPROVED",
-                1001L,
-                9001L,
-                100_000L,
-                "pg-payment-9001",
-                "2026-02-21T05:00:00Z",
-                "sig-abc",
-                null
-        ))).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("eventType is required");
+    private Seat saveSeat(String seatNumber) {
+        Agency agency = agencyRepository.save(new Agency("pg-webhook-agency-" + seatNumber + "-" + System.nanoTime()));
+        Artist artist = artistRepository.save(new Artist("pg-webhook-artist-" + seatNumber + "-" + System.nanoTime(), agency));
+        Concert concert = concertRepository.save(new Concert("pg-webhook-concert-" + seatNumber + "-" + System.nanoTime(), artist));
+        ConcertOption option = concertOptionRepository.save(new ConcertOption(concert, LocalDateTime.now().plusDays(3)));
+        return seatRepository.save(new Seat(option, seatNumber));
     }
 }


### PR DESCRIPTION
## Summary
- extend payment transaction status to `PENDING/SUCCESS/FAILED` and return transaction from reservation payment port
- make `pg-ready` confirm flow asynchronous (`PENDING` at confirm call, webhook `APPROVED/FAILED` drives final transaction state)
- apply webhook reservation transitions (`PAYING -> CONFIRMED`, seat finalize, cache eviction, realtime push)
- add admin override refund audit log table/service and admin audit query endpoint (`GET /api/reservations/v7/audit/admin-refunds`)
- update integration tests for gateway/webhook/reservation lifecycle

## Test
- `./gradlew test --tests '*PgReadyPaymentGatewayIntegrationTest' --tests '*PgReadyWebhookServiceTest' --tests '*ReservationLifecycleServiceIntegrationTest'`

## Issue
- closes #5
