### PR TITLE
feat(stage0): ws auth hardening + atomic queue activation + scheduler lock

### DIFF
--- a/src/main/java/com/ticketrush/api/dto/push/WebSocketQueueSubscriptionRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/push/WebSocketQueueSubscriptionRequest.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 public class WebSocketQueueSubscriptionRequest {
 
-    @NotNull
+    // Optional legacy field. Server authority is always authenticated principal userId.
     private Long userId;
 
     @NotNull

--- a/src/main/java/com/ticketrush/api/dto/push/WebSocketReservationSubscriptionRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/push/WebSocketReservationSubscriptionRequest.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 public class WebSocketReservationSubscriptionRequest {
 
-    @NotNull
+    // Optional legacy field. Server authority is always authenticated principal userId.
     private Long userId;
 
     @NotNull

--- a/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                                 "/api/reservations/v4/**", "/api/reservations/v5/**", "/api/reservations/v6/**").permitAll()
                         .requestMatchers("/api/auth/social/**", "/api/auth/token/refresh").permitAll()
                         .requestMatchers("/api/admin/**").access(adminConsoleAccessManager)
+                        .requestMatchers("/api/push/websocket/**").authenticated()
                         .requestMatchers("/api/reservations/v7/audit/abuse").hasRole("ADMIN")
                         .requestMatchers("/api/reservations/v7/**", "/api/auth/me", "/api/auth/logout").authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/com/ticketrush/global/scheduler/RedissonSchedulerLockService.java
+++ b/src/main/java/com/ticketrush/global/scheduler/RedissonSchedulerLockService.java
@@ -1,0 +1,51 @@
+package com.ticketrush.global.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+public class RedissonSchedulerLockService implements SchedulerLockService {
+
+    private final RedissonClient redissonClient;
+    private final long waitSeconds;
+    private final long leaseSeconds;
+
+    public RedissonSchedulerLockService(
+            RedissonClient redissonClient,
+            @Value("${app.scheduler.lock.wait-seconds:0}") long waitSeconds,
+            @Value("${app.scheduler.lock.lease-seconds:30}") long leaseSeconds
+    ) {
+        this.redissonClient = redissonClient;
+        this.waitSeconds = waitSeconds;
+        this.leaseSeconds = leaseSeconds;
+    }
+
+    @Override
+    public boolean runWithLock(String lockKey, Runnable task) {
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(waitSeconds, leaseSeconds, TimeUnit.SECONDS);
+            if (!acquired) {
+                log.debug("scheduler lock not acquired: {}", lockKey);
+                return false;
+            }
+            task.run();
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("scheduler lock interrupted: {}", lockKey, e);
+            return false;
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/java/com/ticketrush/global/scheduler/ReservationLifecycleScheduler.java
+++ b/src/main/java/com/ticketrush/global/scheduler/ReservationLifecycleScheduler.java
@@ -9,10 +9,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ReservationLifecycleScheduler {
 
+    private static final String EXPIRE_HOLDS_LOCK_KEY = "scheduler:reservation-lifecycle:expire-holds";
+
     private final ReservationLifecycleService reservationLifecycleService;
+    private final SchedulerLockService schedulerLockService;
 
     @Scheduled(fixedDelayString = "${app.reservation.expire-check-delay-millis:5000}")
     public void expireTimedOutHolds() {
-        reservationLifecycleService.expireTimedOutHolds();
+        schedulerLockService.runWithLock(EXPIRE_HOLDS_LOCK_KEY, reservationLifecycleService::expireTimedOutHolds);
     }
 }

--- a/src/main/java/com/ticketrush/global/scheduler/SchedulerLockService.java
+++ b/src/main/java/com/ticketrush/global/scheduler/SchedulerLockService.java
@@ -1,0 +1,6 @@
+package com.ticketrush.global.scheduler;
+
+public interface SchedulerLockService {
+
+    boolean runWithLock(String lockKey, Runnable task);
+}

--- a/src/test/java/com/ticketrush/api/controller/WebSocketPushControllerTest.java
+++ b/src/test/java/com/ticketrush/api/controller/WebSocketPushControllerTest.java
@@ -1,0 +1,90 @@
+package com.ticketrush.api.controller;
+
+import com.ticketrush.api.dto.push.WebSocketQueueSubscriptionRequest;
+import com.ticketrush.api.dto.push.WebSocketReservationSubscriptionRequest;
+import com.ticketrush.domain.auth.security.AuthUserPrincipal;
+import com.ticketrush.domain.user.UserRole;
+import com.ticketrush.global.push.WebSocketPushNotifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketPushControllerTest {
+
+    @Mock
+    private WebSocketPushNotifier webSocketPushNotifier;
+
+    private WebSocketPushController controller;
+    private AuthUserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        controller = new WebSocketPushController(webSocketPushNotifier);
+        principal = new AuthUserPrincipal(200L, "tester", UserRole.USER);
+    }
+
+    @Test
+    void subscribeWaitingQueue_usesAuthenticatedUserId() {
+        WebSocketQueueSubscriptionRequest request = new WebSocketQueueSubscriptionRequest();
+        request.setConcertId(7L);
+
+        when(webSocketPushNotifier.subscribeQueue(200L, 7L))
+                .thenReturn("/topic/waiting-queue/7/200");
+
+        ResponseEntity<Map<String, String>> response = controller.subscribeWaitingQueue(principal, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("destination", "/topic/waiting-queue/7/200");
+        verify(webSocketPushNotifier).subscribeQueue(eq(200L), eq(7L));
+    }
+
+    @Test
+    void subscribeWaitingQueue_whenBodyUserIdMismatched_rejectsRequest() {
+        WebSocketQueueSubscriptionRequest request = new WebSocketQueueSubscriptionRequest();
+        request.setUserId(201L);
+        request.setConcertId(7L);
+
+        assertThatThrownBy(() -> controller.subscribeWaitingQueue(principal, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match");
+
+        verify(webSocketPushNotifier, never()).subscribeQueue(eq(200L), eq(7L));
+    }
+
+    @Test
+    void unsubscribeReservation_usesAuthenticatedUserId() {
+        ResponseEntity<Void> response = controller.unsubscribeReservation(principal, null, 55L);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(204);
+        verify(webSocketPushNotifier).unsubscribeReservation(200L, 55L);
+    }
+
+    @Test
+    void subscribeReservation_whenBodyUserIdMatches_allowsRequest() {
+        WebSocketReservationSubscriptionRequest request = new WebSocketReservationSubscriptionRequest();
+        request.setUserId(200L);
+        request.setSeatId(55L);
+
+        when(webSocketPushNotifier.subscribeReservation(200L, 55L))
+                .thenReturn("/topic/reservations/55/200");
+
+        ResponseEntity<Map<String, String>> response = controller.subscribeReservation(principal, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("destination", "/topic/reservations/55/200");
+        verify(webSocketPushNotifier).subscribeReservation(200L, 55L);
+    }
+}

--- a/src/test/java/com/ticketrush/domain/waitingqueue/service/WaitingQueueServiceImplTest.java
+++ b/src/test/java/com/ticketrush/domain/waitingqueue/service/WaitingQueueServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.ticketrush.domain.waitingqueue.service;
+
+import com.ticketrush.global.config.WaitingQueueProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingQueueServiceImplTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private WaitingQueueProperties properties;
+
+    @InjectMocks
+    private WaitingQueueServiceImpl waitingQueueService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(properties.getQueueKeyPrefix()).thenReturn("waiting-queue:");
+        lenient().when(properties.getActiveKeyPrefix()).thenReturn("active-user:");
+        lenient().when(properties.getActiveTtlMinutes()).thenReturn(5L);
+    }
+
+    @Test
+    void activateUsers_executesLuaScriptAtomically() {
+        when(redisTemplate.execute(
+                any(DefaultRedisScript.class),
+                eq(List.of("waiting-queue:7")),
+                eq("active-user:"),
+                eq("300"),
+                eq("2")
+        )).thenReturn(List.of("1001", "1002"));
+
+        List<Long> activatedUsers = waitingQueueService.activateUsers(7L, 2);
+
+        assertThat(activatedUsers).containsExactly(1001L, 1002L);
+        verify(redisTemplate).execute(
+                any(DefaultRedisScript.class),
+                eq(List.of("waiting-queue:7")),
+                eq("active-user:"),
+                eq("300"),
+                eq("2")
+        );
+    }
+
+    @Test
+    void activateUsers_whenCountIsZero_returnsEmptyWithoutRedisCall() {
+        List<Long> activatedUsers = waitingQueueService.activateUsers(7L, 0);
+
+        assertThat(activatedUsers).isEmpty();
+        verifyNoInteractions(redisTemplate);
+    }
+
+    @Test
+    void activateUsers_whenScriptReturnsNull_returnsEmpty() {
+        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(), any(), any()))
+                .thenReturn(null);
+
+        List<Long> activatedUsers = waitingQueueService.activateUsers(7L, 2);
+
+        assertThat(activatedUsers).isEmpty();
+    }
+}

--- a/src/test/java/com/ticketrush/global/scheduler/ReservationLifecycleSchedulerTest.java
+++ b/src/test/java/com/ticketrush/global/scheduler/ReservationLifecycleSchedulerTest.java
@@ -7,7 +7,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ReservationLifecycleSchedulerTest {
@@ -15,12 +20,33 @@ class ReservationLifecycleSchedulerTest {
     @Mock
     private ReservationLifecycleService reservationLifecycleService;
 
+    @Mock
+    private SchedulerLockService schedulerLockService;
+
     @InjectMocks
     private ReservationLifecycleScheduler reservationLifecycleScheduler;
 
     @Test
     void expireTimedOutHolds_delegateToService() {
+        when(schedulerLockService.runWithLock(anyString(), any()))
+                .thenAnswer(invocation -> {
+                    Runnable task = invocation.getArgument(1);
+                    task.run();
+                    return true;
+                });
+
         reservationLifecycleScheduler.expireTimedOutHolds();
+
+        verify(schedulerLockService).runWithLock(eq("scheduler:reservation-lifecycle:expire-holds"), any());
         verify(reservationLifecycleService).expireTimedOutHolds();
+    }
+
+    @Test
+    void expireTimedOutHolds_whenLockNotAcquired_skipServiceCall() {
+        when(schedulerLockService.runWithLock(anyString(), any())).thenReturn(false);
+
+        reservationLifecycleScheduler.expireTimedOutHolds();
+
+        verify(reservationLifecycleService, never()).expireTimedOutHolds();
     }
 }


### PR DESCRIPTION
## Summary
- Implement Stage 0 pre-work gate before distributed seat-lock implementation.
- Harden websocket subscription boundary to use authenticated principal as source of truth.
- Make waiting-queue activation atomic with Redis Lua script and add distributed lock for schedulers.

## Changes
1. WebSocket subscription auth hardening
- `WebSocketPushController` now uses `@AuthenticationPrincipal` and validates optional request/query `userId` against authenticated user.
- `/api/push/websocket/**` is now authenticated in `SecurityConfig`.
- `WebSocketQueueSubscriptionRequest` / `WebSocketReservationSubscriptionRequest` keep `userId` as optional legacy field only.

2. Waiting queue activation atomicity
- Replaced multi-step `range -> set active -> remove` with Lua script using `ZPOPMIN + SET EX` in one atomic operation.
- Added parsing/guard paths for script result handling.

3. Scheduler distributed lock
- Added `SchedulerLockService` + `RedissonSchedulerLockService`.
- Applied distributed lock around:
  - waiting queue activation scheduler
  - waiting queue heartbeat scheduler
  - reservation hold-expire scheduler

4. Tests
- Added `WebSocketPushControllerTest`.
- Added `WaitingQueueServiceImplTest`.
- Updated scheduler tests to include lock-acquired / lock-not-acquired paths.

## Verification
- `./gradlew test --tests '*WebSocketPushControllerTest' --tests '*WaitingQueueServiceImplTest' --tests '*WaitingQueueSchedulerTest' --tests '*ReservationLifecycleSchedulerTest'`

## Issue
- closes #22
