### PR TITLE
feat(reservation): add v7 seat soft lock + seat-map websocket fan-out

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/WebSocketPushController.java
+++ b/src/main/java/com/ticketrush/api/controller/WebSocketPushController.java
@@ -2,6 +2,7 @@ package com.ticketrush.api.controller;
 
 import com.ticketrush.api.dto.push.WebSocketQueueSubscriptionRequest;
 import com.ticketrush.api.dto.push.WebSocketReservationSubscriptionRequest;
+import com.ticketrush.api.dto.push.WebSocketSeatMapSubscriptionRequest;
 import com.ticketrush.domain.auth.security.AuthUserPrincipal;
 import com.ticketrush.global.push.WebSocketPushNotifier;
 import jakarta.validation.Valid;
@@ -73,6 +74,29 @@ public class WebSocketPushController {
         Long authenticatedUserId = requiredUserId(principal);
         validateRequestedUserId(userId, authenticatedUserId);
         webSocketPushNotifier.unsubscribeReservation(authenticatedUserId, seatId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/seats/subscriptions")
+    public ResponseEntity<Map<String, String>> subscribeSeatMap(
+            @AuthenticationPrincipal AuthUserPrincipal principal,
+            @Valid @RequestBody WebSocketSeatMapSubscriptionRequest request
+    ) {
+        requiredUserId(principal);
+        String destination = webSocketPushNotifier.subscribeSeatMap(request.getOptionId());
+        return ResponseEntity.ok(Map.of(
+                "transport", "websocket",
+                "destination", destination
+        ));
+    }
+
+    @DeleteMapping("/seats/subscriptions")
+    public ResponseEntity<Void> unsubscribeSeatMap(
+            @AuthenticationPrincipal AuthUserPrincipal principal,
+            @RequestParam Long optionId
+    ) {
+        requiredUserId(principal);
+        webSocketPushNotifier.unsubscribeSeatMap(optionId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/ticketrush/api/dto/push/WebSocketSeatMapSubscriptionRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/push/WebSocketSeatMapSubscriptionRequest.java
@@ -1,0 +1,13 @@
+package com.ticketrush.api.dto.push;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebSocketSeatMapSubscriptionRequest {
+
+    @NotNull
+    private Long optionId;
+}

--- a/src/main/java/com/ticketrush/api/dto/reservation/SeatSoftLockAcquireResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/reservation/SeatSoftLockAcquireResponse.java
@@ -1,0 +1,30 @@
+package com.ticketrush.api.dto.reservation;
+
+import com.ticketrush.domain.reservation.service.SeatSoftLockService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SeatSoftLockAcquireResponse {
+
+    private Long optionId;
+    private Long seatId;
+    private Long ownerUserId;
+    private String status;
+    private String requestId;
+    private String expiresAt;
+    private Long ttlSeconds;
+
+    public static SeatSoftLockAcquireResponse from(SeatSoftLockService.SeatSoftLockAcquireResult result) {
+        return new SeatSoftLockAcquireResponse(
+                result.optionId(),
+                result.seatId(),
+                result.ownerUserId(),
+                result.status(),
+                result.requestId(),
+                result.expiresAt(),
+                result.ttlSeconds()
+        );
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/reservation/SeatSoftLockReleaseResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/reservation/SeatSoftLockReleaseResponse.java
@@ -1,0 +1,24 @@
+package com.ticketrush.api.dto.reservation;
+
+import com.ticketrush.domain.reservation.service.SeatSoftLockService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SeatSoftLockReleaseResponse {
+
+    private Long optionId;
+    private Long seatId;
+    private String status;
+    private boolean released;
+
+    public static SeatSoftLockReleaseResponse from(SeatSoftLockService.SeatSoftLockReleaseResult result) {
+        return new SeatSoftLockReleaseResponse(
+                result.optionId(),
+                result.seatId(),
+                result.status(),
+                result.released()
+        );
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/reservation/SeatSoftLockRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/reservation/SeatSoftLockRequest.java
@@ -1,0 +1,11 @@
+package com.ticketrush.api.dto.reservation;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SeatSoftLockRequest {
+
+    private String requestId;
+}

--- a/src/main/java/com/ticketrush/domain/reservation/service/SeatSoftLockService.java
+++ b/src/main/java/com/ticketrush/domain/reservation/service/SeatSoftLockService.java
@@ -1,0 +1,33 @@
+package com.ticketrush.domain.reservation.service;
+
+import java.time.LocalDateTime;
+
+public interface SeatSoftLockService {
+
+    SeatSoftLockAcquireResult acquire(Long userId, Long seatId, String requestId);
+
+    SeatSoftLockReleaseResult release(Long userId, Long seatId);
+
+    void ensureHoldableByUser(Long userId, Long seatId);
+
+    void promoteToHold(Long userId, Long seatId, LocalDateTime holdExpiresAt);
+
+    record SeatSoftLockAcquireResult(
+            Long optionId,
+            Long seatId,
+            Long ownerUserId,
+            String status,
+            String requestId,
+            String expiresAt,
+            Long ttlSeconds
+    ) {
+    }
+
+    record SeatSoftLockReleaseResult(
+            Long optionId,
+            Long seatId,
+            String status,
+            boolean released
+    ) {
+    }
+}

--- a/src/main/java/com/ticketrush/domain/reservation/service/SeatSoftLockServiceImpl.java
+++ b/src/main/java/com/ticketrush/domain/reservation/service/SeatSoftLockServiceImpl.java
@@ -1,0 +1,143 @@
+package com.ticketrush.domain.reservation.service;
+
+import com.ticketrush.domain.concert.entity.Seat;
+import com.ticketrush.domain.reservation.port.outbound.ReservationSeatPort;
+import com.ticketrush.global.config.ReservationProperties;
+import com.ticketrush.global.push.PushNotifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class SeatSoftLockServiceImpl implements SeatSoftLockService {
+
+    private static final String STATUS_SELECTING = "SELECTING";
+    private static final String STATUS_RELEASED = "RELEASED";
+    private static final String STATUS_HOLD = "HOLD";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ReservationSeatPort reservationSeatPort;
+    private final ReservationProperties reservationProperties;
+    private final PushNotifier pushNotifier;
+
+    @Override
+    public SeatSoftLockAcquireResult acquire(Long userId, Long seatId, String requestId) {
+        SeatContext context = seatContext(seatId);
+        long ttlSeconds = normalizedTtlSeconds();
+        String resolvedRequestId = resolveRequestId(requestId, userId, seatId);
+        String expiresAt = Instant.now().plusSeconds(ttlSeconds).toString();
+        String key = context.key();
+        String encodedValue = encode(new LockValue(userId, resolvedRequestId, expiresAt));
+
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, encodedValue, ttlSeconds, TimeUnit.SECONDS);
+        if (!Boolean.TRUE.equals(acquired)) {
+            LockValue current = decode(redisTemplate.opsForValue().get(key));
+            if (current == null || !userId.equals(current.ownerUserId())) {
+                throw new IllegalStateException("Seat is already selecting by another user. seatId=" + seatId);
+            }
+            redisTemplate.opsForValue().set(key, encodedValue, ttlSeconds, TimeUnit.SECONDS);
+        }
+
+        pushNotifier.sendSeatMapStatus(context.optionId(), seatId, STATUS_SELECTING, userId, expiresAt);
+        return new SeatSoftLockAcquireResult(
+                context.optionId(),
+                seatId,
+                userId,
+                STATUS_SELECTING,
+                resolvedRequestId,
+                expiresAt,
+                ttlSeconds
+        );
+    }
+
+    @Override
+    public SeatSoftLockReleaseResult release(Long userId, Long seatId) {
+        SeatContext context = seatContext(seatId);
+        String key = context.key();
+        LockValue current = decode(redisTemplate.opsForValue().get(key));
+
+        if (current == null) {
+            return new SeatSoftLockReleaseResult(context.optionId(), seatId, STATUS_RELEASED, false);
+        }
+        if (!userId.equals(current.ownerUserId())) {
+            throw new IllegalStateException("Seat soft lock owner mismatch. seatId=" + seatId);
+        }
+
+        redisTemplate.delete(key);
+        pushNotifier.sendSeatMapStatus(context.optionId(), seatId, STATUS_RELEASED, null, null);
+        return new SeatSoftLockReleaseResult(context.optionId(), seatId, STATUS_RELEASED, true);
+    }
+
+    @Override
+    public void ensureHoldableByUser(Long userId, Long seatId) {
+        SeatContext context = seatContext(seatId);
+        LockValue current = decode(redisTemplate.opsForValue().get(context.key()));
+        if (current != null && !userId.equals(current.ownerUserId())) {
+            throw new IllegalStateException("Seat is selecting by another user. seatId=" + seatId);
+        }
+    }
+
+    @Override
+    public void promoteToHold(Long userId, Long seatId, LocalDateTime holdExpiresAt) {
+        SeatContext context = seatContext(seatId);
+        redisTemplate.delete(context.key());
+        pushNotifier.sendSeatMapStatus(
+                context.optionId(),
+                seatId,
+                STATUS_HOLD,
+                userId,
+                holdExpiresAt == null ? null : holdExpiresAt.toInstant(ZoneOffset.UTC).toString()
+        );
+    }
+
+    private SeatContext seatContext(Long seatId) {
+        Seat seat = reservationSeatPort.getSeat(seatId);
+        Long optionId = seat.getConcertOption().getId();
+        String key = reservationProperties.getSoftLockKeyPrefix() + optionId + ":" + seatId;
+        return new SeatContext(optionId, key);
+    }
+
+    private long normalizedTtlSeconds() {
+        return Math.max(1L, reservationProperties.getSoftLockTtlSeconds());
+    }
+
+    private String resolveRequestId(String requestId, Long userId, Long seatId) {
+        if (StringUtils.hasText(requestId)) {
+            return requestId.trim();
+        }
+        return "soft-lock-" + userId + "-" + seatId + "-" + System.currentTimeMillis();
+    }
+
+    private String encode(LockValue value) {
+        return value.ownerUserId() + "|" + value.requestId() + "|" + value.expiresAt();
+    }
+
+    private LockValue decode(String rawValue) {
+        if (!StringUtils.hasText(rawValue)) {
+            return null;
+        }
+        String[] parts = rawValue.split("\\|", 3);
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            Long ownerUserId = Long.parseLong(parts[0]);
+            return new LockValue(ownerUserId, parts[1], parts[2]);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private record LockValue(Long ownerUserId, String requestId, String expiresAt) {
+    }
+
+    private record SeatContext(Long optionId, String key) {
+    }
+}

--- a/src/main/java/com/ticketrush/global/config/ReservationProperties.java
+++ b/src/main/java/com/ticketrush/global/config/ReservationProperties.java
@@ -17,6 +17,16 @@ public class ReservationProperties {
     private long holdTtlSeconds = 300;
 
     /**
+     * 좌석 선택(soft lock) 유지 시간.
+     */
+    private long softLockTtlSeconds = 30;
+
+    /**
+     * 좌석 soft lock Redis key prefix.
+     */
+    private String softLockKeyPrefix = "seat:lock:";
+
+    /**
      * 만료 스캔 스케줄러 주기.
      */
     private long expireCheckDelayMillis = 5_000;

--- a/src/main/java/com/ticketrush/global/push/PushNotifier.java
+++ b/src/main/java/com/ticketrush/global/push/PushNotifier.java
@@ -13,4 +13,8 @@ public interface PushNotifier {
     void sendQueueHeartbeat();
 
     Set<Long> getSubscribedQueueUsers(Long concertId);
+
+    default void sendSeatMapStatus(Long optionId, Long seatId, String status, Long ownerUserId, String expiresAt) {
+        // Optional capability. Implementations without seat-map channel support can ignore.
+    }
 }

--- a/src/main/java/com/ticketrush/global/push/WebSocketPushNotifier.java
+++ b/src/main/java/com/ticketrush/global/push/WebSocketPushNotifier.java
@@ -7,6 +7,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -19,6 +20,7 @@ public class WebSocketPushNotifier implements PushNotifier {
 
     private static final String WAITING_QUEUE_TOPIC_PREFIX = "/topic/waiting-queue";
     private static final String RESERVATION_TOPIC_PREFIX = "/topic/reservations";
+    private static final String SEAT_MAP_TOPIC_PREFIX = "/topic/seats";
 
     private final SimpMessagingTemplate messagingTemplate;
     private final Map<Long, Set<Long>> queueSubscribersByConcert = new ConcurrentHashMap<>();
@@ -49,6 +51,14 @@ public class WebSocketPushNotifier implements PushNotifier {
 
     public void unsubscribeReservation(Long userId, Long seatId) {
         reservationSubscriptions.remove(reservationKey(userId, seatId));
+    }
+
+    public String subscribeSeatMap(Long optionId) {
+        return seatMapDestination(optionId);
+    }
+
+    public void unsubscribeSeatMap(Long optionId) {
+        // STOMP topic subscription lifecycle is managed by broker/client session.
     }
 
     @Override
@@ -94,6 +104,24 @@ public class WebSocketPushNotifier implements PushNotifier {
         return new HashSet<>(users);
     }
 
+    @Override
+    public void sendSeatMapStatus(Long optionId, Long seatId, String status, Long ownerUserId, String expiresAt) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("event", "SEAT_STATUS");
+        payload.put("optionId", optionId);
+        payload.put("seatId", seatId);
+        payload.put("status", status);
+        payload.put("transport", "websocket");
+        payload.put("timestamp", Instant.now().toString());
+        if (ownerUserId != null) {
+            payload.put("ownerUserId", ownerUserId);
+        }
+        if (expiresAt != null) {
+            payload.put("expiresAt", expiresAt);
+        }
+        messagingTemplate.convertAndSend(seatMapDestination(optionId), payload);
+    }
+
     private void sendQueueEvent(Long userId, Long concertId, String eventName, Object data) {
         messagingTemplate.convertAndSend(
                 queueDestination(userId, concertId),
@@ -116,5 +144,9 @@ public class WebSocketPushNotifier implements PushNotifier {
 
     private String reservationKey(Long userId, Long seatId) {
         return userId + ":" + seatId;
+    }
+
+    private String seatMapDestination(Long optionId) {
+        return SEAT_MAP_TOPIC_PREFIX + "/" + optionId;
     }
 }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -38,6 +38,8 @@ app:
       reservation: "ticket-reservation-events"
   reservation:
     hold-ttl-seconds: 300
+    soft-lock-ttl-seconds: 30
+    soft-lock-key-prefix: "seat:lock:"
     expire-check-delay-millis: 5000
     refund-cutoff-hours-before-concert: 24
   payment:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -57,6 +57,8 @@ app:
       reservation: "ticket-reservation-events"
   reservation:
     hold-ttl-seconds: 300
+    soft-lock-ttl-seconds: 30
+    soft-lock-key-prefix: "seat:lock:"
     expire-check-delay-millis: 5000
     refund-cutoff-hours-before-concert: 24
   payment:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,8 @@ app:
       reservation: "ticket-reservation-events"
   reservation:
     hold-ttl-seconds: 300
+    soft-lock-ttl-seconds: 30
+    soft-lock-key-prefix: "seat:lock:"
     expire-check-delay-millis: 5000
     refund-cutoff-hours-before-concert: 24
   payment:

--- a/src/test/java/com/ticketrush/api/controller/WebSocketPushControllerTest.java
+++ b/src/test/java/com/ticketrush/api/controller/WebSocketPushControllerTest.java
@@ -2,6 +2,7 @@ package com.ticketrush.api.controller;
 
 import com.ticketrush.api.dto.push.WebSocketQueueSubscriptionRequest;
 import com.ticketrush.api.dto.push.WebSocketReservationSubscriptionRequest;
+import com.ticketrush.api.dto.push.WebSocketSeatMapSubscriptionRequest;
 import com.ticketrush.domain.auth.security.AuthUserPrincipal;
 import com.ticketrush.domain.user.UserRole;
 import com.ticketrush.global.push.WebSocketPushNotifier;
@@ -86,5 +87,27 @@ class WebSocketPushControllerTest {
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody()).containsEntry("destination", "/topic/reservations/55/200");
         verify(webSocketPushNotifier).subscribeReservation(200L, 55L);
+    }
+
+    @Test
+    void subscribeSeatMap_returnsTopicDestination() {
+        WebSocketSeatMapSubscriptionRequest request = new WebSocketSeatMapSubscriptionRequest();
+        request.setOptionId(19L);
+
+        when(webSocketPushNotifier.subscribeSeatMap(19L)).thenReturn("/topic/seats/19");
+
+        ResponseEntity<Map<String, String>> response = controller.subscribeSeatMap(principal, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("destination", "/topic/seats/19");
+        verify(webSocketPushNotifier).subscribeSeatMap(19L);
+    }
+
+    @Test
+    void unsubscribeSeatMap_returnsNoContent() {
+        ResponseEntity<Void> response = controller.unsubscribeSeatMap(principal, 19L);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(204);
+        verify(webSocketPushNotifier).unsubscribeSeatMap(19L);
     }
 }

--- a/src/test/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceIntegrationTest.java
+++ b/src/test/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceIntegrationTest.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -183,6 +184,20 @@ class ReservationLifecycleServiceIntegrationTest {
         assertThat(seatRepository.findById(seat.getId()).orElseThrow().getStatus())
                 .isEqualTo(Seat.SeatStatus.RESERVED);
         assertThat(paymentService.getWalletBalance(user.getId())).isEqualTo(100_000L);
+        verify(pushNotifier).sendSeatMapStatus(
+                eq(seat.getConcertOption().getId()),
+                eq(seat.getId()),
+                eq(Reservation.ReservationStatus.HOLD.name()),
+                eq(user.getId()),
+                any()
+        );
+        verify(pushNotifier).sendSeatMapStatus(
+                eq(seat.getConcertOption().getId()),
+                eq(seat.getId()),
+                eq(Reservation.ReservationStatus.CONFIRMED.name()),
+                eq(user.getId()),
+                isNull()
+        );
     }
 
     @Test
@@ -204,6 +219,13 @@ class ReservationLifecycleServiceIntegrationTest {
         assertThat(seatRepository.findById(seat.getId()).orElseThrow().getStatus())
                 .isEqualTo(Seat.SeatStatus.AVAILABLE);
         verify(pushNotifier).sendReservationStatus(user.getId(), seat.getId(), Reservation.ReservationStatus.EXPIRED.name());
+        verify(pushNotifier).sendSeatMapStatus(
+                eq(seat.getConcertOption().getId()),
+                eq(seat.getId()),
+                eq(Seat.SeatStatus.AVAILABLE.name()),
+                isNull(),
+                isNull()
+        );
     }
 
     @Test
@@ -231,6 +253,13 @@ class ReservationLifecycleServiceIntegrationTest {
 
         verify(waitingQueueService).activateUsers(concertId, 1);
         verify(pushNotifier).sendQueueActivated(eq(999L), eq(concertId), any());
+        verify(pushNotifier).sendSeatMapStatus(
+                eq(seat.getConcertOption().getId()),
+                eq(seat.getId()),
+                eq(Seat.SeatStatus.AVAILABLE.name()),
+                isNull(),
+                isNull()
+        );
     }
 
     @Test

--- a/src/test/java/com/ticketrush/domain/reservation/service/SeatSoftLockServiceImplTest.java
+++ b/src/test/java/com/ticketrush/domain/reservation/service/SeatSoftLockServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.ticketrush.domain.reservation.service;
+
+import com.ticketrush.domain.agency.Agency;
+import com.ticketrush.domain.artist.Artist;
+import com.ticketrush.domain.concert.entity.Concert;
+import com.ticketrush.domain.concert.entity.ConcertOption;
+import com.ticketrush.domain.concert.entity.Seat;
+import com.ticketrush.domain.reservation.port.outbound.ReservationSeatPort;
+import com.ticketrush.global.config.ReservationProperties;
+import com.ticketrush.global.push.PushNotifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SeatSoftLockServiceImplTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private ReservationSeatPort reservationSeatPort;
+
+    @Mock
+    private PushNotifier pushNotifier;
+
+    private SeatSoftLockServiceImpl seatSoftLockService;
+
+    @BeforeEach
+    void setUp() {
+        ReservationProperties reservationProperties = new ReservationProperties();
+        reservationProperties.setSoftLockTtlSeconds(30);
+        reservationProperties.setSoftLockKeyPrefix("seat:lock:");
+
+        seatSoftLockService = new SeatSoftLockServiceImpl(
+                redisTemplate,
+                reservationSeatPort,
+                reservationProperties,
+                pushNotifier
+        );
+
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(reservationSeatPort.getSeat(55L)).thenReturn(buildSeat(11L, 55L));
+    }
+
+    @Test
+    void acquire_whenKeyIsEmpty_setsNxAndBroadcastsSelecting() {
+        when(valueOperations.setIfAbsent(
+                eq("seat:lock:11:55"),
+                anyString(),
+                eq(30L),
+                eq(TimeUnit.SECONDS)
+        )).thenReturn(true);
+
+        SeatSoftLockService.SeatSoftLockAcquireResult result = seatSoftLockService.acquire(200L, 55L, "req-1");
+
+        assertThat(result.optionId()).isEqualTo(11L);
+        assertThat(result.seatId()).isEqualTo(55L);
+        assertThat(result.ownerUserId()).isEqualTo(200L);
+        assertThat(result.status()).isEqualTo("SELECTING");
+        assertThat(result.requestId()).isEqualTo("req-1");
+        assertThat(result.expiresAt()).isNotBlank();
+        assertThat(result.ttlSeconds()).isEqualTo(30L);
+        verify(pushNotifier).sendSeatMapStatus(11L, 55L, "SELECTING", 200L, result.expiresAt());
+    }
+
+    @Test
+    void ensureHoldableByUser_whenForeignLockExists_throwsConflict() {
+        when(valueOperations.get("seat:lock:11:55")).thenReturn("999|req-x|2026-02-22T02:00:00Z");
+
+        assertThatThrownBy(() -> seatSoftLockService.ensureHoldableByUser(200L, 55L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("another user");
+    }
+
+    @Test
+    void release_whenOwnerMatches_deletesKeyAndBroadcastsReleased() {
+        when(valueOperations.get("seat:lock:11:55")).thenReturn("200|req-x|2026-02-22T02:00:00Z");
+
+        SeatSoftLockService.SeatSoftLockReleaseResult result = seatSoftLockService.release(200L, 55L);
+
+        assertThat(result.optionId()).isEqualTo(11L);
+        assertThat(result.seatId()).isEqualTo(55L);
+        assertThat(result.status()).isEqualTo("RELEASED");
+        assertThat(result.released()).isTrue();
+        verify(redisTemplate).delete("seat:lock:11:55");
+        verify(pushNotifier).sendSeatMapStatus(11L, 55L, "RELEASED", null, null);
+    }
+
+    @Test
+    void promoteToHold_clearsSoftLockAndBroadcastsHold() {
+        LocalDateTime holdExpiresAt = LocalDateTime.of(2026, 2, 22, 2, 5, 0);
+
+        seatSoftLockService.promoteToHold(200L, 55L, holdExpiresAt);
+
+        verify(redisTemplate).delete("seat:lock:11:55");
+        verify(pushNotifier).sendSeatMapStatus(
+                eq(11L),
+                eq(55L),
+                eq("HOLD"),
+                eq(200L),
+                anyString()
+        );
+    }
+
+    private Seat buildSeat(Long optionId, Long seatId) {
+        Agency agency = new Agency("soft-lock-agency-" + seatId);
+        Artist artist = new Artist("soft-lock-artist-" + seatId, agency);
+        Concert concert = new Concert("soft-lock-concert-" + seatId, artist);
+        ConcertOption option = new ConcertOption(concert, LocalDateTime.now().plusDays(1));
+        Seat seat = new Seat(option, "A-" + seatId);
+
+        ReflectionTestUtils.setField(option, "id", optionId);
+        ReflectionTestUtils.setField(seat, "id", seatId);
+        return seat;
+    }
+}


### PR DESCRIPTION
## Summary
- add Redis soft-lock service for seat selecting (`SET NX EX`)
- add v7 lock APIs (`POST/DELETE /api/reservations/v7/locks/seats/{seatId}`)
- wire v7 hold flow to block foreign soft-lock owner and promote soft-lock -> HOLD
- add websocket seat-map subscription APIs (`/api/push/websocket/seats/subscriptions`)
- broadcast seat-map state transitions (`SELECTING/HOLD/CONFIRMED/AVAILABLE/RELEASED`) from websocket notifier
- add config keys: `app.reservation.soft-lock-ttl-seconds`, `soft-lock-key-prefix`

## Verification
- `./gradlew test --tests '*WebSocketPushControllerTest' --tests '*SeatSoftLockServiceImplTest' --tests '*ReservationLifecycleServiceIntegrationTest'`

## Issue
- closes #21
