### PR TITLE
feat(realtime): phase2 relay-ready broker + redis subscriber tracking

### DIFF
--- a/src/main/java/com/ticketrush/global/config/WaitingQueueProperties.java
+++ b/src/main/java/com/ticketrush/global/config/WaitingQueueProperties.java
@@ -19,4 +19,7 @@ public class WaitingQueueProperties {
     private long sseHeartbeatDelayMillis;
     private String queueKeyPrefix;
     private String activeKeyPrefix;
+    private long wsSubscriberTtlSeconds = 90;
+    private String wsSubscriberZsetKeyPrefix = "ws:queue:subs:";
+    private String wsConcertIndexKey = "ws:queue:concerts";
 }

--- a/src/main/java/com/ticketrush/global/config/WebSocketBrokerProperties.java
+++ b/src/main/java/com/ticketrush/global/config/WebSocketBrokerProperties.java
@@ -1,0 +1,29 @@
+package com.ticketrush.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.websocket.broker")
+public class WebSocketBrokerProperties {
+
+    private Mode mode = Mode.SIMPLE;
+    private String relayHost = "localhost";
+    private int relayPort = 61613;
+    private String relayClientLogin = "guest";
+    private String relayClientPasscode = "guest";
+    private String relaySystemLogin = "guest";
+    private String relaySystemPasscode = "guest";
+    private String relayVirtualHost = "/";
+    private long relaySystemHeartbeatSendInterval = 10_000L;
+    private long relaySystemHeartbeatReceiveInterval = 10_000L;
+
+    public enum Mode {
+        SIMPLE,
+        RELAY
+    }
+}

--- a/src/main/java/com/ticketrush/global/config/WebSocketConfig.java
+++ b/src/main/java/com/ticketrush/global/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.ticketrush.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
@@ -10,20 +11,23 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 
 import java.util.List;
 
+@Slf4j
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final List<String> normalizedAllowedOrigins;
+    private final WebSocketBrokerProperties brokerProperties;
 
     public WebSocketConfig(
-            @Value("${app.frontend.allowed-origins:http://localhost:8080,http://127.0.0.1:8080}")
-            List<String> allowedOrigins
+            @Value("${app.frontend.allowed-origins:http://localhost:8080,http://127.0.0.1:8080}") List<String> allowedOrigins,
+            WebSocketBrokerProperties brokerProperties
     ) {
         this.normalizedAllowedOrigins = allowedOrigins.stream()
                 .map(String::trim)
                 .filter(StringUtils::hasText)
                 .toList();
+        this.brokerProperties = brokerProperties;
     }
 
     @Override
@@ -34,7 +38,26 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic");
+        if (brokerProperties.getMode() == WebSocketBrokerProperties.Mode.RELAY) {
+            log.info(
+                    "WebSocket broker mode: RELAY host={} port={}",
+                    brokerProperties.getRelayHost(),
+                    brokerProperties.getRelayPort()
+            );
+            registry.enableStompBrokerRelay("/topic")
+                    .setRelayHost(brokerProperties.getRelayHost())
+                    .setRelayPort(brokerProperties.getRelayPort())
+                    .setClientLogin(brokerProperties.getRelayClientLogin())
+                    .setClientPasscode(brokerProperties.getRelayClientPasscode())
+                    .setSystemLogin(brokerProperties.getRelaySystemLogin())
+                    .setSystemPasscode(brokerProperties.getRelaySystemPasscode())
+                    .setVirtualHost(brokerProperties.getRelayVirtualHost())
+                    .setSystemHeartbeatSendInterval(brokerProperties.getRelaySystemHeartbeatSendInterval())
+                    .setSystemHeartbeatReceiveInterval(brokerProperties.getRelaySystemHeartbeatReceiveInterval());
+        } else {
+            log.info("WebSocket broker mode: SIMPLE");
+            registry.enableSimpleBroker("/topic");
+        }
         registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -48,6 +48,9 @@ app:
   waiting-queue:
     queue-key-prefix: "waiting-queue:"
     active-key-prefix: "active-user:"
+    ws-subscriber-zset-key-prefix: "ws:queue:subs:"
+    ws-concert-index-key: "ws:queue:concerts"
+    ws-subscriber-ttl-seconds: 300
     max-queue-size: 100
     active-ttl-minutes: 5
     activation-batch-size: 10

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -67,6 +67,9 @@ app:
   waiting-queue:
     queue-key-prefix: "waiting-queue:"
     active-key-prefix: "active-user:"
+    ws-subscriber-zset-key-prefix: "ws:queue:subs:"
+    ws-concert-index-key: "ws:queue:concerts"
+    ws-subscriber-ttl-seconds: 300
     max-queue-size: 100
     active-ttl-minutes: 5
     activation-batch-size: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,9 +38,24 @@ app:
     minimum-role: USER
   push:
     mode: ${APP_PUSH_MODE:websocket}
+  websocket:
+    broker:
+      mode: ${APP_WS_BROKER_MODE:simple}
+      relay-host: ${APP_WS_RELAY_HOST:localhost}
+      relay-port: ${APP_WS_RELAY_PORT:61613}
+      relay-client-login: ${APP_WS_RELAY_CLIENT_LOGIN:guest}
+      relay-client-passcode: ${APP_WS_RELAY_CLIENT_PASSCODE:guest}
+      relay-system-login: ${APP_WS_RELAY_SYSTEM_LOGIN:guest}
+      relay-system-passcode: ${APP_WS_RELAY_SYSTEM_PASSCODE:guest}
+      relay-virtual-host: ${APP_WS_RELAY_VIRTUAL_HOST:/}
+      relay-system-heartbeat-send-interval: ${APP_WS_RELAY_SYSTEM_HEARTBEAT_SEND_INTERVAL:10000}
+      relay-system-heartbeat-receive-interval: ${APP_WS_RELAY_SYSTEM_HEARTBEAT_RECEIVE_INTERVAL:10000}
   waiting-queue:
     queue-key-prefix: "waiting-queue:"
     active-key-prefix: "active-user:"
+    ws-subscriber-zset-key-prefix: "ws:queue:subs:"
+    ws-concert-index-key: "ws:queue:concerts"
+    ws-subscriber-ttl-seconds: 300
     max-queue-size: 100
     active-ttl-minutes: 5
     activation-batch-size: 10

--- a/src/test/java/com/ticketrush/global/config/WebSocketConfigTest.java
+++ b/src/test/java/com/ticketrush/global/config/WebSocketConfigTest.java
@@ -1,0 +1,71 @@
+package com.ticketrush.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.config.SimpleBrokerRegistration;
+import org.springframework.messaging.simp.config.StompBrokerRelayRegistration;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebSocketConfigTest {
+
+    @Test
+    void configureMessageBroker_simpleMode_usesSimpleBroker() {
+        WebSocketBrokerProperties brokerProperties = new WebSocketBrokerProperties();
+        brokerProperties.setMode(WebSocketBrokerProperties.Mode.SIMPLE);
+
+        WebSocketConfig config = new WebSocketConfig(List.of("http://localhost:8080"), brokerProperties);
+
+        MessageBrokerRegistry registry = mock(MessageBrokerRegistry.class);
+        SimpleBrokerRegistration simpleBrokerRegistration = mock(SimpleBrokerRegistration.class);
+        when(registry.enableSimpleBroker("/topic")).thenReturn(simpleBrokerRegistration);
+
+        config.configureMessageBroker(registry);
+
+        verify(registry).enableSimpleBroker("/topic");
+        verify(registry, never()).enableStompBrokerRelay("/topic");
+        verify(registry).setApplicationDestinationPrefixes("/app");
+    }
+
+    @Test
+    void configureMessageBroker_relayMode_usesRelayBroker() {
+        WebSocketBrokerProperties brokerProperties = new WebSocketBrokerProperties();
+        brokerProperties.setMode(WebSocketBrokerProperties.Mode.RELAY);
+        brokerProperties.setRelayHost("rabbitmq");
+        brokerProperties.setRelayPort(61614);
+        brokerProperties.setRelayClientLogin("client");
+        brokerProperties.setRelayClientPasscode("client-pass");
+        brokerProperties.setRelaySystemLogin("system");
+        brokerProperties.setRelaySystemPasscode("system-pass");
+        brokerProperties.setRelayVirtualHost("/");
+        brokerProperties.setRelaySystemHeartbeatSendInterval(1111L);
+        brokerProperties.setRelaySystemHeartbeatReceiveInterval(2222L);
+
+        WebSocketConfig config = new WebSocketConfig(List.of("http://localhost:8080"), brokerProperties);
+
+        MessageBrokerRegistry registry = mock(MessageBrokerRegistry.class);
+        StompBrokerRelayRegistration relayRegistration = mock(StompBrokerRelayRegistration.class, Answers.RETURNS_SELF);
+        when(registry.enableStompBrokerRelay("/topic")).thenReturn(relayRegistration);
+
+        config.configureMessageBroker(registry);
+
+        verify(registry).enableStompBrokerRelay("/topic");
+        verify(registry, never()).enableSimpleBroker("/topic");
+        verify(relayRegistration).setRelayHost("rabbitmq");
+        verify(relayRegistration).setRelayPort(61614);
+        verify(relayRegistration).setClientLogin("client");
+        verify(relayRegistration).setClientPasscode("client-pass");
+        verify(relayRegistration).setSystemLogin("system");
+        verify(relayRegistration).setSystemPasscode("system-pass");
+        verify(relayRegistration).setVirtualHost("/");
+        verify(relayRegistration).setSystemHeartbeatSendInterval(1111L);
+        verify(relayRegistration).setSystemHeartbeatReceiveInterval(2222L);
+        verify(registry).setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/test/java/com/ticketrush/global/push/WebSocketPushNotifierTest.java
+++ b/src/test/java/com/ticketrush/global/push/WebSocketPushNotifierTest.java
@@ -1,34 +1,90 @@
 package com.ticketrush.global.push;
 
+import com.ticketrush.global.config.WaitingQueueProperties;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class WebSocketPushNotifierTest {
 
     @Test
-    void subscribeQueue_shouldTrackSubscribedUsersByConcert() {
+    void subscribeQueue_shouldPersistSubscriptionToRedis() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
+        SetOperations<String, String> setOperations = mock(SetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
 
         String destination = notifier.subscribeQueue(100L, 1L);
 
         assertThat(destination).isEqualTo("/topic/waiting-queue/1/100");
-        assertThat(notifier.getSubscribedQueueUsers(1L)).isEqualTo(Set.of(100L));
+        verify(zSetOperations).add(eq("ws:queue:subs:1"), eq("100"), anyDouble());
+        verify(setOperations).add("ws:queue:concerts", "1");
+    }
+
+    @Test
+    void getSubscribedQueueUsers_shouldReadFromRedis() {
+        SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
+        SetOperations<String, String> setOperations = mock(SetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        when(zSetOperations.rangeByScore(eq("ws:queue:subs:1"), anyDouble(), anyDouble()))
+                .thenReturn(Set.of("100", "101"));
+
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
+
+        Set<Long> users = notifier.getSubscribedQueueUsers(1L);
+
+        assertThat(users).containsExactlyInAnyOrder(100L, 101L);
+    }
+
+    @Test
+    void sendQueueHeartbeat_shouldPublishToSubscribedUsers() {
+        SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
+        SetOperations<String, String> setOperations = mock(SetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        when(setOperations.members("ws:queue:concerts")).thenReturn(Set.of("1"));
+        when(zSetOperations.rangeByScore(eq("ws:queue:subs:1"), anyDouble(), anyDouble()))
+                .thenReturn(Set.of("100"));
+
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
+
+        notifier.sendQueueHeartbeat();
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/waiting-queue/1/100"), anyMap());
     }
 
     @Test
     void sendQueueActivated_shouldPublishToWaitingQueueTopic() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
+        SetOperations<String, String> setOperations = mock(SetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
 
         notifier.sendQueueActivated(100L, 1L, Map.of("status", "ACTIVE"));
 
@@ -38,10 +94,24 @@ class WebSocketPushNotifierTest {
     @Test
     void sendReservationStatus_shouldPublishToReservationTopic() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
+        SetOperations<String, String> setOperations = mock(SetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
 
         notifier.sendReservationStatus(100L, 500L, "SUCCESS");
 
         verify(messagingTemplate).convertAndSend(eq("/topic/reservations/500/100"), anyMap());
+    }
+
+    private WaitingQueueProperties waitingQueueProperties() {
+        WaitingQueueProperties properties = new WaitingQueueProperties();
+        properties.setWsSubscriberZsetKeyPrefix("ws:queue:subs:");
+        properties.setWsConcertIndexKey("ws:queue:concerts");
+        properties.setWsSubscriberTtlSeconds(300);
+        return properties;
     }
 }


### PR DESCRIPTION
## Summary
- add relay-ready WebSocket broker configuration (`simple`/`relay` mode)
- replace WebSocket waiting-queue subscriber tracking from in-memory map to Redis ZSET + index set
- keep scheduler fan-out API intact while making subscriber lookup multi-node aware
- add coverage tests for broker mode selection and redis-backed subscriber behavior

## Details
- new properties:
  - `app.websocket.broker.mode` (`simple` | `relay`)
  - `app.websocket.broker.relay-*`
  - `app.waiting-queue.ws-subscriber-zset-key-prefix`
  - `app.waiting-queue.ws-concert-index-key`
  - `app.waiting-queue.ws-subscriber-ttl-seconds`
- `WebSocketPushNotifier#getSubscribedQueueUsers` now reads from Redis and prunes expired entries.

## Verification
- `./gradlew test --tests '*WebSocketConfigTest' --tests '*WebSocketPushNotifierTest' --tests '*WaitingQueueSchedulerTest'`
- `./gradlew test --tests '*WebSocketPushNotifierTest' --tests '*SeatSoftLockServiceImplTest' --tests '*ReservationLifecycleServiceIntegrationTest' --tests '*WaitingQueueSchedulerTest' --tests '*WebSocketPushControllerTest'`

## Issue
- part of #21 (phase2)
