### PR TITLE
chore(runtime): distributed relay baseline + compose root alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- DOC_META_START -->
 > [!NOTE]
 > - **Created At**: `2026-02-09 00:33:02`
-> - **Updated At**: `2026-02-18 23:52:32`
+> - **Updated At**: `2026-02-22 20:20:00`
 <!-- DOC_META_END -->
 
 <!-- DOC_TOC_START -->
@@ -58,6 +58,15 @@ make test-suite
 make test-k6
 ```
 
+### 4-1. 분산 환경 실행 (3 app + LB + WS relay)
+```bash
+docker-compose -f docker-compose.distributed.yml up -d --build
+```
+
+```bash
+make test-k6-distributed
+```
+
 ### 5. Auth-Social CI-safe 파이프라인 테스트
 ```bash
 make test-auth-social-pipeline
@@ -84,7 +93,15 @@ make test-auth-social-real-provider
 - auth-social 파이프라인 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/auth-social-e2e-latest.md`
 - auth-social real provider e2e 리포트 기본 경로: `.codex/tmp/ticket-core-service/api-test/auth-social-real-provider-e2e-latest.md`
 - k6 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/k6/latest/k6-latest.md`
+- 분산 compose 경로: `docker-compose.distributed.yml`
 - 실시간 푸시 모드 스위치: `APP_PUSH_MODE=sse|websocket` (기본값 `websocket`)
+- WS broker 모드 스위치: `APP_WS_BROKER_MODE=simple|relay` (기본값 `simple`)
+- 분산 compose 기본값:
+  - `APP_WS_BROKER_MODE=relay`
+  - relay host/port/login은 compose 내부 `ws-relay` 기준으로 주입
+- 운영 오버라이드 가능한 핵심 설정:
+  - `APP_RESERVATION_SOFT_LOCK_TTL_SECONDS` (기본 `30`)
+  - `APP_PAYMENT_PROVIDER` (기본 `wallet`)
 - WebSocket STOMP 엔드포인트: `/ws` (`/topic/waiting-queue/{concertId}/{userId}`, `/topic/reservations/{seatId}/{userId}`)
 - WebSocket 구독 등록 API:
   - `POST /api/push/websocket/waiting-queue/subscriptions`

--- a/docker-compose.distributed.yml
+++ b/docker-compose.distributed.yml
@@ -63,59 +63,101 @@ services:
     networks:
       - ticket-network
 
+  ws-relay:
+    image: rabbitmq:3.13-management
+    environment:
+      RABBITMQ_DEFAULT_USER: relayuser
+      RABBITMQ_DEFAULT_PASS: relaypass
+    command: >
+      sh -c "rabbitmq-plugins enable --offline rabbitmq_stomp && rabbitmq-server"
+    healthcheck:
+      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - ticket-network
+
   app-node-1:
     build:
-      context: ../..
+      context: .
     env_file:
-      - ../../.env.local
+      - .env.local
     environment:
       SPRING_PROFILES_ACTIVE: docker
       APP_PUSH_MODE: websocket
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+      APP_WS_BROKER_MODE: relay
+      APP_WS_RELAY_HOST: ws-relay
+      APP_WS_RELAY_PORT: 61613
+      APP_WS_RELAY_CLIENT_LOGIN: relayuser
+      APP_WS_RELAY_CLIENT_PASSCODE: relaypass
+      APP_WS_RELAY_SYSTEM_LOGIN: relayuser
+      APP_WS_RELAY_SYSTEM_PASSCODE: relaypass
     depends_on:
       postgres-db:
         condition: service_healthy
       redis:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      ws-relay:
         condition: service_healthy
     networks:
       - ticket-network
 
   app-node-2:
     build:
-      context: ../..
+      context: .
     env_file:
-      - ../../.env.local
+      - .env.local
     environment:
       SPRING_PROFILES_ACTIVE: docker
       APP_PUSH_MODE: websocket
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+      APP_WS_BROKER_MODE: relay
+      APP_WS_RELAY_HOST: ws-relay
+      APP_WS_RELAY_PORT: 61613
+      APP_WS_RELAY_CLIENT_LOGIN: relayuser
+      APP_WS_RELAY_CLIENT_PASSCODE: relaypass
+      APP_WS_RELAY_SYSTEM_LOGIN: relayuser
+      APP_WS_RELAY_SYSTEM_PASSCODE: relaypass
     depends_on:
       postgres-db:
         condition: service_healthy
       redis:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      ws-relay:
         condition: service_healthy
     networks:
       - ticket-network
 
   app-node-3:
     build:
-      context: ../..
+      context: .
     env_file:
-      - ../../.env.local
+      - .env.local
     environment:
       SPRING_PROFILES_ACTIVE: docker
       APP_PUSH_MODE: websocket
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+      APP_WS_BROKER_MODE: relay
+      APP_WS_RELAY_HOST: ws-relay
+      APP_WS_RELAY_PORT: 61613
+      APP_WS_RELAY_CLIENT_LOGIN: relayuser
+      APP_WS_RELAY_CLIENT_PASSCODE: relaypass
+      APP_WS_RELAY_SYSTEM_LOGIN: relayuser
+      APP_WS_RELAY_SYSTEM_PASSCODE: relaypass
     depends_on:
       postgres-db:
         condition: service_healthy
       redis:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      ws-relay:
         condition: service_healthy
     networks:
       - ticket-network
@@ -129,7 +171,7 @@ services:
     ports:
       - "18080:8080"
     volumes:
-      - ./nginx/k6-distributed-lb.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./scripts/perf/nginx/k6-distributed-lb.conf:/etc/nginx/conf.d/default.conf:ro
     networks:
       - ticket-network
 

--- a/scripts/perf/run-k6-waiting-queue-distributed.sh
+++ b/scripts/perf/run-k6-waiting-queue-distributed.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 project_abs="$(cd "$script_dir/../.." && pwd)"
 repo_root="$(git -C "$project_abs" rev-parse --show-toplevel 2>/dev/null || echo "$project_abs")"
 
-compose_file="${DIST_COMPOSE_FILE:-$project_abs/scripts/perf/docker-compose.distributed.yml}"
+compose_file="${DIST_COMPOSE_FILE:-$project_abs/docker-compose.distributed.yml}"
 compose_project="${DIST_COMPOSE_PROJECT:-tcsdist}"
 lb_service="${DIST_LB_SERVICE_NAME:-nginx-lb}"
 docker_network="${DIST_DOCKER_NETWORK:-${compose_project}_ticket-network}"

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -38,12 +38,12 @@ app:
       reservation: "ticket-reservation-events"
   reservation:
     hold-ttl-seconds: 300
-    soft-lock-ttl-seconds: 30
+    soft-lock-ttl-seconds: ${APP_RESERVATION_SOFT_LOCK_TTL_SECONDS:30}
     soft-lock-key-prefix: "seat:lock:"
     expire-check-delay-millis: 5000
     refund-cutoff-hours-before-concert: 24
   payment:
-    provider: wallet
+    provider: ${APP_PAYMENT_PROVIDER:wallet}
     default-ticket-price-amount: 100000
   waiting-queue:
     queue-key-prefix: "waiting-queue:"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -57,12 +57,12 @@ app:
       reservation: "ticket-reservation-events"
   reservation:
     hold-ttl-seconds: 300
-    soft-lock-ttl-seconds: 30
+    soft-lock-ttl-seconds: ${APP_RESERVATION_SOFT_LOCK_TTL_SECONDS:30}
     soft-lock-key-prefix: "seat:lock:"
     expire-check-delay-millis: 5000
     refund-cutoff-hours-before-concert: 24
   payment:
-    provider: wallet
+    provider: ${APP_PAYMENT_PROVIDER:wallet}
     default-ticket-price-amount: 100000
   waiting-queue:
     queue-key-prefix: "waiting-queue:"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,12 +27,12 @@ app:
       reservation: "ticket-reservation-events"
   reservation:
     hold-ttl-seconds: 300
-    soft-lock-ttl-seconds: 30
+    soft-lock-ttl-seconds: ${APP_RESERVATION_SOFT_LOCK_TTL_SECONDS:30}
     soft-lock-key-prefix: "seat:lock:"
     expire-check-delay-millis: 5000
     refund-cutoff-hours-before-concert: 24
   payment:
-    provider: wallet
+    provider: ${APP_PAYMENT_PROVIDER:wallet}
     default-ticket-price-amount: 100000
   admin-console:
     minimum-role: USER


### PR DESCRIPTION
## Related Issue
- #21

## Why
- Keep distributed runtime entrypoint stable at project root compose.
- Use relay mode as distributed default instead of per-node simple broker behavior.
- Make core runtime defaults explicit env overrides for operations.

## What Changed
1. Moved distributed compose to project root: `docker-compose.distributed.yml`.
2. Added in-compose STOMP relay service (`ws-relay`) and set app nodes default to `APP_WS_BROKER_MODE=relay`.
3. Updated distributed k6 runner default compose path to project root file.
4. Switched key defaults to env-overridable forms:
   - `APP_RESERVATION_SOFT_LOCK_TTL_SECONDS`
   - `APP_PAYMENT_PROVIDER`
5. Updated README runtime guidance for distributed entrypoint and override keys.

## Verification
- `bash -n scripts/perf/run-k6-waiting-queue-distributed.sh`
- `docker-compose -f docker-compose.distributed.yml config`

## Issue Lifecycle
- Same scope follow-up on #21; reopened and updated instead of creating a new issue.
