### PR TITLE
chore: phase1 remove ws-relay baseline for kafka-only migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,11 @@ make test-auth-social-real-provider
 - k6 실행 리포트 기본 경로: `.codex/tmp/ticket-core-service/k6/latest/k6-latest.md`
 - 분산/단일 공통 compose 경로: `docker-compose.yml`
 - 실시간 푸시 모드 스위치: `APP_PUSH_MODE=sse|websocket` (기본값 `websocket`)
-- WS broker 모드 스위치: `APP_WS_BROKER_MODE=simple|relay` (기본값 `relay`)
+- WS broker 모드 스위치: `APP_WS_BROKER_MODE=simple|relay` (기본값 `simple`)
 - compose 기본값:
-  - `APP_WS_BROKER_MODE=relay`
-  - relay host/port/login은 compose 내부 `ws-relay` 기준으로 주입
+  - `APP_WS_BROKER_MODE=simple`
   - app 인스턴스 수는 `--scale app=<N>`으로 조절
-  - 로컬 `bootRun` 단독 실행 시 relay 미기동이면 `APP_WS_BROKER_MODE=simple`로 오버라이드
+  - relay 모드를 사용할 경우 별도 STOMP relay 브로커를 외부에서 제공해야 함
 - 운영 오버라이드 가능한 핵심 설정:
   - `APP_RESERVATION_SOFT_LOCK_TTL_SECONDS` (기본 `30`)
   - `APP_PAYMENT_PROVIDER` (기본 `wallet`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,21 +73,6 @@ services:
     networks:
       - ticket-network
 
-  ws-relay:
-    image: rabbitmq:3.13-management
-    environment:
-      RABBITMQ_DEFAULT_USER: relayuser
-      RABBITMQ_DEFAULT_PASS: relaypass
-    command: >
-      sh -c "rabbitmq-plugins enable --offline rabbitmq_stomp && rabbitmq-server"
-    healthcheck:
-      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-    networks:
-      - ticket-network
-
   app:
     build: .
     env_file:
@@ -98,21 +83,13 @@ services:
       SPRING_PROFILES_ACTIVE: docker
       APP_PUSH_MODE: ${APP_PUSH_MODE:-websocket}
       KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
-      APP_WS_BROKER_MODE: ${APP_WS_BROKER_MODE:-relay}
-      APP_WS_RELAY_HOST: ${APP_WS_RELAY_HOST:-ws-relay}
-      APP_WS_RELAY_PORT: ${APP_WS_RELAY_PORT:-61613}
-      APP_WS_RELAY_CLIENT_LOGIN: ${APP_WS_RELAY_CLIENT_LOGIN:-relayuser}
-      APP_WS_RELAY_CLIENT_PASSCODE: ${APP_WS_RELAY_CLIENT_PASSCODE:-relaypass}
-      APP_WS_RELAY_SYSTEM_LOGIN: ${APP_WS_RELAY_SYSTEM_LOGIN:-relayuser}
-      APP_WS_RELAY_SYSTEM_PASSCODE: ${APP_WS_RELAY_SYSTEM_PASSCODE:-relaypass}
+      APP_WS_BROKER_MODE: ${APP_WS_BROKER_MODE:-simple}
     depends_on:
       postgres-db:
         condition: service_healthy
       redis:
         condition: service_healthy
       kafka:
-        condition: service_healthy
-      ws-relay:
         condition: service_healthy
     networks:
       - ticket-network

--- a/src/main/java/com/ticketrush/global/config/WebSocketBrokerProperties.java
+++ b/src/main/java/com/ticketrush/global/config/WebSocketBrokerProperties.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "app.websocket.broker")
 public class WebSocketBrokerProperties {
 
-    private Mode mode = Mode.RELAY;
+    private Mode mode = Mode.SIMPLE;
     private String relayHost = "localhost";
     private int relayPort = 61613;
     private String relayClientLogin = "guest";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ app:
     mode: ${APP_PUSH_MODE:websocket}
   websocket:
     broker:
-      mode: ${APP_WS_BROKER_MODE:relay}
+      mode: ${APP_WS_BROKER_MODE:simple}
       relay-host: ${APP_WS_RELAY_HOST:localhost}
       relay-port: ${APP_WS_RELAY_PORT:61613}
       relay-client-login: ${APP_WS_RELAY_CLIENT_LOGIN:guest}


### PR DESCRIPTION
- Primary: #3

## Issue Lifecycle Decision
- [x] Reopen/Update existing issue (same scope)
- [ ] New issue (different scope only)
- Issue: #3

## Summary
- remove `ws-relay` (RabbitMQ STOMP relay) from compose runtime baseline
- remove relay env defaults from app compose runtime
- reset WS broker default mode from `relay` to `simple`
- align backend README runtime guidance with the updated default

## Verification
- `docker-compose -f docker-compose.yml config`
- `./gradlew test --tests '*WebSocketConfigTest'`

## Note
- this PR is phase-1 baseline cleanup for TCS-SC-024
- issue #3 remains open for phase-2 Kafka-only multi-instance fanout redesign
