### PR TITLE
feat: kafka-only websocket fanout for distributed runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ make test-auth-social-real-provider
 - compose 기본값:
   - `APP_WS_BROKER_MODE=simple`
   - app 인스턴스 수는 `--scale app=<N>`으로 조절
-  - relay 모드를 사용할 경우 별도 STOMP relay 브로커를 외부에서 제공해야 함
+  - 다중 인스턴스 fanout은 Kafka push topic(`app.kafka.topic.push`) 기반으로 처리
+  - relay 모드를 사용할 경우 별도 STOMP relay 브로커를 외부에서 제공해야 함(기본 미사용)
+- Kafka push fanout 설정:
+  - `APP_KAFKA_TOPIC_PUSH` (기본 `ticket-push-events`)
+  - `APP_KAFKA_PUSH_CONSUMER_GROUP_ID` (기본 `${spring.application.name}-${random.uuid}`; 인스턴스별 고유 group)
 - 운영 오버라이드 가능한 핵심 설정:
   - `APP_RESERVATION_SOFT_LOCK_TTL_SECONDS` (기본 `30`)
   - `APP_PAYMENT_PROVIDER` (기본 `wallet`)

--- a/src/main/java/com/ticketrush/global/config/PushNotifierConfig.java
+++ b/src/main/java/com/ticketrush/global/config/PushNotifierConfig.java
@@ -18,11 +18,11 @@ public class PushNotifierConfig {
     public PushNotifier pushNotifier(
             PushProperties properties,
             @Qualifier("ssePushNotifier") PushNotifier ssePushNotifier,
-            @Qualifier("webSocketPushNotifier") PushNotifier webSocketPushNotifier
+            @Qualifier("kafkaWebSocketPushNotifier") PushNotifier kafkaWebSocketPushNotifier
     ) {
         if (properties.getMode() == PushProperties.Mode.WEBSOCKET) {
-            log.info("Push notifier mode: WEBSOCKET");
-            return webSocketPushNotifier;
+            log.info("Push notifier mode: WEBSOCKET (Kafka fanout)");
+            return kafkaWebSocketPushNotifier;
         }
 
         log.info("Push notifier mode: SSE");

--- a/src/main/java/com/ticketrush/global/messaging/KafkaPushEvent.java
+++ b/src/main/java/com/ticketrush/global/messaging/KafkaPushEvent.java
@@ -1,0 +1,33 @@
+package com.ticketrush.global.messaging;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaPushEvent {
+
+    private Type type;
+    private Long userId;
+    private Long concertId;
+    private Long seatId;
+    private Long optionId;
+    private String status;
+    private String eventName;
+    private Object data;
+    private Long ownerUserId;
+    private String expiresAt;
+    private String timestamp;
+
+    public enum Type {
+        QUEUE_EVENT,
+        RESERVATION_STATUS,
+        SEAT_MAP_STATUS
+    }
+}

--- a/src/main/java/com/ticketrush/global/messaging/KafkaPushEventConsumer.java
+++ b/src/main/java/com/ticketrush/global/messaging/KafkaPushEventConsumer.java
@@ -1,0 +1,50 @@
+package com.ticketrush.global.messaging;
+
+import com.ticketrush.global.push.WebSocketPushNotifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaPushEventConsumer {
+
+    private final WebSocketPushNotifier webSocketPushNotifier;
+
+    @KafkaListener(
+            topics = "${app.kafka.topic.push}",
+            groupId = "${app.kafka.push.consumer-group-id:${spring.application.name:ticket-core-service}-${random.uuid}}",
+            properties = {
+                    "auto.offset.reset=latest"
+            }
+    )
+    public void consume(KafkaPushEvent event) {
+        if (event == null || event.getType() == null) {
+            return;
+        }
+
+        switch (event.getType()) {
+            case QUEUE_EVENT -> webSocketPushNotifier.publishQueueEvent(
+                    event.getUserId(),
+                    event.getConcertId(),
+                    event.getEventName(),
+                    event.getData()
+            );
+            case RESERVATION_STATUS -> webSocketPushNotifier.sendReservationStatus(
+                    event.getUserId(),
+                    event.getSeatId(),
+                    event.getStatus()
+            );
+            case SEAT_MAP_STATUS -> webSocketPushNotifier.sendSeatMapStatus(
+                    event.getOptionId(),
+                    event.getSeatId(),
+                    event.getStatus(),
+                    event.getOwnerUserId(),
+                    event.getExpiresAt()
+            );
+            default -> log.debug("Unsupported push event type: {}", event.getType());
+        }
+    }
+}

--- a/src/main/java/com/ticketrush/global/messaging/KafkaPushEventProducer.java
+++ b/src/main/java/com/ticketrush/global/messaging/KafkaPushEventProducer.java
@@ -1,0 +1,23 @@
+package com.ticketrush.global.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaPushEventProducer {
+
+    private final KafkaTemplate<String, KafkaPushEvent> kafkaTemplate;
+
+    @Value("${app.kafka.topic.push}")
+    private String topic;
+
+    public void publish(KafkaPushEvent event, String key) {
+        log.debug("Publishing push event to Kafka - Topic: {}, Type: {}, Key: {}", topic, event.getType(), key);
+        kafkaTemplate.send(topic, key, event);
+    }
+}

--- a/src/main/java/com/ticketrush/global/push/KafkaWebSocketPushNotifier.java
+++ b/src/main/java/com/ticketrush/global/push/KafkaWebSocketPushNotifier.java
@@ -1,0 +1,104 @@
+package com.ticketrush.global.push;
+
+import com.ticketrush.global.messaging.KafkaPushEvent;
+import com.ticketrush.global.messaging.KafkaPushEventProducer;
+import com.ticketrush.global.sse.SseEventNames;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Component("kafkaWebSocketPushNotifier")
+@RequiredArgsConstructor
+public class KafkaWebSocketPushNotifier implements PushNotifier {
+
+    private final KafkaPushEventProducer producer;
+    private final WebSocketPushNotifier webSocketPushNotifier;
+
+    @Override
+    public void sendReservationStatus(Long userId, Long seatId, String status) {
+        producer.publish(
+                KafkaPushEvent.builder()
+                        .type(KafkaPushEvent.Type.RESERVATION_STATUS)
+                        .userId(userId)
+                        .seatId(seatId)
+                        .status(status)
+                        .timestamp(Instant.now().toString())
+                        .build(),
+                reservationKey(userId, seatId)
+        );
+    }
+
+    @Override
+    public void sendQueueRankUpdate(Long userId, Long concertId, Object data) {
+        publishQueueEvent(userId, concertId, SseEventNames.RANK_UPDATE, data);
+    }
+
+    @Override
+    public void sendQueueActivated(Long userId, Long concertId, Object data) {
+        publishQueueEvent(userId, concertId, SseEventNames.ACTIVE, data);
+    }
+
+    @Override
+    public void sendQueueHeartbeat() {
+        String timestamp = Instant.now().toString();
+        Map<Long, Set<Long>> snapshot = webSocketPushNotifier.snapshotQueueSubscribers();
+        for (Map.Entry<Long, Set<Long>> entry : snapshot.entrySet()) {
+            Long concertId = entry.getKey();
+            for (Long userId : entry.getValue()) {
+                publishQueueEvent(userId, concertId, SseEventNames.KEEPALIVE, Map.of("timestamp", timestamp));
+            }
+        }
+    }
+
+    @Override
+    public Set<Long> getSubscribedQueueUsers(Long concertId) {
+        return webSocketPushNotifier.getSubscribedQueueUsers(concertId);
+    }
+
+    @Override
+    public void sendSeatMapStatus(Long optionId, Long seatId, String status, Long ownerUserId, String expiresAt) {
+        producer.publish(
+                KafkaPushEvent.builder()
+                        .type(KafkaPushEvent.Type.SEAT_MAP_STATUS)
+                        .optionId(optionId)
+                        .seatId(seatId)
+                        .status(status)
+                        .ownerUserId(ownerUserId)
+                        .expiresAt(expiresAt)
+                        .timestamp(Instant.now().toString())
+                        .build(),
+                seatMapKey(optionId, seatId)
+        );
+    }
+
+    private void publishQueueEvent(Long userId, Long concertId, String eventName, Object data) {
+        producer.publish(
+                KafkaPushEvent.builder()
+                        .type(KafkaPushEvent.Type.QUEUE_EVENT)
+                        .userId(userId)
+                        .concertId(concertId)
+                        .eventName(eventName)
+                        .data(data)
+                        .timestamp(Instant.now().toString())
+                        .build(),
+                queueKey(userId, concertId)
+        );
+    }
+
+    private String queueKey(Long userId, Long concertId) {
+        return "queue:" + concertId + ":" + userId;
+    }
+
+    private String reservationKey(Long userId, Long seatId) {
+        return "reservation:" + seatId + ":" + userId;
+    }
+
+    private String seatMapKey(Long optionId, Long seatId) {
+        return "seat-map:" + optionId + ":" + seatId;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,9 @@ app:
   kafka:
     topic:
       reservation: "ticket-reservation-events"
+      push: ${APP_KAFKA_TOPIC_PUSH:ticket-push-events}
+    push:
+      consumer-group-id: ${APP_KAFKA_PUSH_CONSUMER_GROUP_ID:${spring.application.name:ticket-core-service}-${random.uuid}}
   reservation:
     hold-ttl-seconds: 300
     soft-lock-ttl-seconds: ${APP_RESERVATION_SOFT_LOCK_TTL_SECONDS:30}

--- a/src/test/java/com/ticketrush/global/config/PushNotifierConfigTest.java
+++ b/src/test/java/com/ticketrush/global/config/PushNotifierConfigTest.java
@@ -23,23 +23,23 @@ class PushNotifierConfigTest {
         properties.setMode(PushProperties.Mode.SSE);
 
         PushNotifier ssePushNotifier = mock(PushNotifier.class);
-        PushNotifier webSocketPushNotifier = mock(PushNotifier.class);
+        PushNotifier kafkaWebSocketPushNotifier = mock(PushNotifier.class);
 
-        PushNotifier selected = config.pushNotifier(properties, ssePushNotifier, webSocketPushNotifier);
+        PushNotifier selected = config.pushNotifier(properties, ssePushNotifier, kafkaWebSocketPushNotifier);
 
         assertThat(selected).isSameAs(ssePushNotifier);
     }
 
     @Test
-    void pushNotifier_shouldSelectWebSocketWhenModeIsWebsocket() {
+    void pushNotifier_shouldSelectKafkaWebSocketWhenModeIsWebsocket() {
         PushProperties properties = new PushProperties();
         properties.setMode(PushProperties.Mode.WEBSOCKET);
 
         PushNotifier ssePushNotifier = mock(PushNotifier.class);
-        PushNotifier webSocketPushNotifier = mock(PushNotifier.class);
+        PushNotifier kafkaWebSocketPushNotifier = mock(PushNotifier.class);
 
-        PushNotifier selected = config.pushNotifier(properties, ssePushNotifier, webSocketPushNotifier);
+        PushNotifier selected = config.pushNotifier(properties, ssePushNotifier, kafkaWebSocketPushNotifier);
 
-        assertThat(selected).isSameAs(webSocketPushNotifier);
+        assertThat(selected).isSameAs(kafkaWebSocketPushNotifier);
     }
 }

--- a/src/test/java/com/ticketrush/global/messaging/KafkaPushEventConsumerTest.java
+++ b/src/test/java/com/ticketrush/global/messaging/KafkaPushEventConsumerTest.java
@@ -1,0 +1,66 @@
+package com.ticketrush.global.messaging;
+
+import com.ticketrush.global.push.WebSocketPushNotifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class KafkaPushEventConsumerTest {
+
+    @Test
+    void consume_queueEvent_shouldDispatchToWebSocketNotifier() {
+        WebSocketPushNotifier webSocketPushNotifier = mock(WebSocketPushNotifier.class);
+        KafkaPushEventConsumer consumer = new KafkaPushEventConsumer(webSocketPushNotifier);
+
+        KafkaPushEvent event = KafkaPushEvent.builder()
+                .type(KafkaPushEvent.Type.QUEUE_EVENT)
+                .userId(10L)
+                .concertId(20L)
+                .eventName("RANK_UPDATE")
+                .data(Map.of("rank", 1))
+                .build();
+
+        consumer.consume(event);
+
+        verify(webSocketPushNotifier).publishQueueEvent(10L, 20L, "RANK_UPDATE", Map.of("rank", 1));
+    }
+
+    @Test
+    void consume_reservationStatus_shouldDispatchToWebSocketNotifier() {
+        WebSocketPushNotifier webSocketPushNotifier = mock(WebSocketPushNotifier.class);
+        KafkaPushEventConsumer consumer = new KafkaPushEventConsumer(webSocketPushNotifier);
+
+        KafkaPushEvent event = KafkaPushEvent.builder()
+                .type(KafkaPushEvent.Type.RESERVATION_STATUS)
+                .userId(10L)
+                .seatId(99L)
+                .status("CONFIRMED")
+                .build();
+
+        consumer.consume(event);
+
+        verify(webSocketPushNotifier).sendReservationStatus(10L, 99L, "CONFIRMED");
+    }
+
+    @Test
+    void consume_seatMapStatus_shouldDispatchToWebSocketNotifier() {
+        WebSocketPushNotifier webSocketPushNotifier = mock(WebSocketPushNotifier.class);
+        KafkaPushEventConsumer consumer = new KafkaPushEventConsumer(webSocketPushNotifier);
+
+        KafkaPushEvent event = KafkaPushEvent.builder()
+                .type(KafkaPushEvent.Type.SEAT_MAP_STATUS)
+                .optionId(7L)
+                .seatId(55L)
+                .status("SELECTING")
+                .ownerUserId(100L)
+                .expiresAt("2026-02-22T14:30:00Z")
+                .build();
+
+        consumer.consume(event);
+
+        verify(webSocketPushNotifier).sendSeatMapStatus(7L, 55L, "SELECTING", 100L, "2026-02-22T14:30:00Z");
+    }
+}

--- a/src/test/java/com/ticketrush/global/push/KafkaWebSocketPushNotifierTest.java
+++ b/src/test/java/com/ticketrush/global/push/KafkaWebSocketPushNotifierTest.java
@@ -1,0 +1,62 @@
+package com.ticketrush.global.push;
+
+import com.ticketrush.global.messaging.KafkaPushEvent;
+import com.ticketrush.global.messaging.KafkaPushEventProducer;
+import com.ticketrush.global.sse.SseEventNames;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class KafkaWebSocketPushNotifierTest {
+
+    @Test
+    void sendQueueActivated_shouldPublishQueueEventToKafka() {
+        KafkaPushEventProducer producer = mock(KafkaPushEventProducer.class);
+        WebSocketPushNotifier webSocketPushNotifier = mock(WebSocketPushNotifier.class);
+        KafkaWebSocketPushNotifier notifier = new KafkaWebSocketPushNotifier(producer, webSocketPushNotifier);
+
+        notifier.sendQueueActivated(11L, 22L, Map.of("status", "ACTIVE"));
+
+        var eventCaptor = forClass(KafkaPushEvent.class);
+        var keyCaptor = forClass(String.class);
+        verify(producer).publish(eventCaptor.capture(), keyCaptor.capture());
+
+        assertThat(eventCaptor.getValue().getType()).isEqualTo(KafkaPushEvent.Type.QUEUE_EVENT);
+        assertThat(eventCaptor.getValue().getEventName()).isEqualTo(SseEventNames.ACTIVE);
+        assertThat(eventCaptor.getValue().getUserId()).isEqualTo(11L);
+        assertThat(eventCaptor.getValue().getConcertId()).isEqualTo(22L);
+        assertThat(keyCaptor.getValue()).isEqualTo("queue:22:11");
+    }
+
+    @Test
+    void sendQueueHeartbeat_shouldPublishKeepaliveForEachSubscriber() {
+        KafkaPushEventProducer producer = mock(KafkaPushEventProducer.class);
+        WebSocketPushNotifier webSocketPushNotifier = mock(WebSocketPushNotifier.class);
+        when(webSocketPushNotifier.snapshotQueueSubscribers()).thenReturn(Map.of(1L, Set.of(10L, 11L)));
+
+        KafkaWebSocketPushNotifier notifier = new KafkaWebSocketPushNotifier(producer, webSocketPushNotifier);
+        notifier.sendQueueHeartbeat();
+
+        verify(producer).publish(org.mockito.ArgumentMatchers.any(KafkaPushEvent.class), org.mockito.ArgumentMatchers.eq("queue:1:10"));
+        verify(producer).publish(org.mockito.ArgumentMatchers.any(KafkaPushEvent.class), org.mockito.ArgumentMatchers.eq("queue:1:11"));
+    }
+
+    @Test
+    void getSubscribedQueueUsers_shouldDelegateToWebSocketNotifier() {
+        KafkaPushEventProducer producer = mock(KafkaPushEventProducer.class);
+        WebSocketPushNotifier webSocketPushNotifier = mock(WebSocketPushNotifier.class);
+        when(webSocketPushNotifier.getSubscribedQueueUsers(9L)).thenReturn(Set.of(100L));
+
+        KafkaWebSocketPushNotifier notifier = new KafkaWebSocketPushNotifier(producer, webSocketPushNotifier);
+        Set<Long> users = notifier.getSubscribedQueueUsers(9L);
+
+        assertThat(users).containsExactly(100L);
+    }
+}


### PR DESCRIPTION
- Primary: #3

## Issue Lifecycle Decision
- [x] Reopen/Update existing issue (same scope)
- [ ] New issue (different scope only)
- Issue: #3

## Summary
- add Kafka-backed websocket fanout path (`KafkaWebSocketPushNotifier`) for distributed runtime
- add push event topic pipeline (`KafkaPushEventProducer` / `KafkaPushEventConsumer`)
- keep websocket simple broker local delivery (`WebSocketPushNotifier`) and fanout through Kafka per-instance consume
- add queue subscriber snapshot helper for heartbeat fanout publishing
- update push config and runtime docs for Kafka push topic/group defaults

## Verification
- `docker-compose -f docker-compose.yml config`
- `./gradlew test --tests '*PushNotifierConfigTest' --tests '*WebSocketPushNotifierTest' --tests '*KafkaWebSocketPushNotifierTest' --tests '*KafkaPushEventConsumerTest' --tests '*WebSocketConfigTest'`
- `./gradlew test --tests '*WaitingQueueSchedulerTest' --tests '*SeatSoftLockServiceImplTest' --tests '*ReservationLifecycleServiceIntegrationTest'`

Closes #3
