### PR TITLE
feat: finalize idempotent seed strategy for local/demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ make test-auth-social-real-provider
 - 운영 오버라이드 가능한 핵심 설정:
   - `APP_RESERVATION_SOFT_LOCK_TTL_SECONDS` (기본 `30`)
   - `APP_PAYMENT_PROVIDER` (기본 `wallet`)
+- 초기 시드 전략:
+  - 관리 계정 시드: `APP_SEED_ADMIN_ENABLED` (기본 `true`, `admin` 계정 1회 생성)
+  - 포트폴리오 샘플 시드: `APP_PORTFOLIO_SEED_ENABLED=true`일 때만 실행
+  - 포트폴리오 시드 허용 프로필: `APP_PORTFOLIO_SEED_PROFILES` (기본 `local,demo`)
+  - idempotent 마커 키: `APP_PORTFOLIO_SEED_MARKER_KEY` (기본 `portfolio_seed_marker_v1`)
+  - 프로덕션 안전성: 허용 프로필 외에서는 포트폴리오 시드가 비활성화됩니다.
 - WebSocket STOMP 엔드포인트: `/ws` (`/topic/waiting-queue/{concertId}/{userId}`, `/topic/reservations/{seatId}/{userId}`)
 - WebSocket 구독 등록 API:
   - `POST /api/push/websocket/waiting-queue/subscriptions`

--- a/src/main/java/com/ticketrush/DataInitializer.java
+++ b/src/main/java/com/ticketrush/DataInitializer.java
@@ -1,36 +1,385 @@
 package com.ticketrush;
 
+import com.ticketrush.domain.artist.Artist;
+import com.ticketrush.domain.artist.ArtistRepository;
+import com.ticketrush.domain.concert.entity.Concert;
+import com.ticketrush.domain.concert.entity.ConcertOption;
+import com.ticketrush.domain.concert.entity.Seat;
+import com.ticketrush.domain.concert.repository.ConcertOptionRepository;
+import com.ticketrush.domain.concert.repository.ConcertRepository;
+import com.ticketrush.domain.concert.repository.SeatRepository;
+import com.ticketrush.domain.entertainment.Entertainment;
+import com.ticketrush.domain.entertainment.EntertainmentRepository;
+import com.ticketrush.domain.promoter.Promoter;
+import com.ticketrush.domain.promoter.PromoterRepository;
+import com.ticketrush.domain.reservation.entity.SalesPolicy;
+import com.ticketrush.domain.reservation.repository.SalesPolicyRepository;
+import com.ticketrush.domain.seed.SeedMarker;
+import com.ticketrush.domain.seed.SeedMarkerRepository;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRole;
 import com.ticketrush.domain.user.UserRepository;
 import com.ticketrush.domain.user.UserTier;
+import com.ticketrush.domain.venue.Venue;
+import com.ticketrush.domain.venue.VenueRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
 /**
- * [System] 초기 시스템 기동 확인용 데이터 이니셜라이저
- * 상세한 테스트 데이터는 /api/concerts/setup API를 통해 동적으로 생성하십시오.
+ * [System] 초기 시스템 데이터 시드
+ * - 관리 계정 시드: 기본 활성화
+ * - 포트폴리오 샘플 시드: local/demo profile + runtime flag 활성 시에만 적용
+ * - idempotent marker 기반으로 1회만 적용
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
 
+    private static final String ADMIN_USERNAME = "admin";
+    private static final int DEFAULT_MAX_RESERVATIONS_PER_USER = 4;
+    private static final int DEFAULT_SEAT_COUNT = 20;
+    private static final int SOLD_OUT_SEAT_COUNT = 8;
+    private static final long DEFAULT_TICKET_PRICE_AMOUNT = 132_000L;
+
     private final UserRepository userRepository;
+    private final SeedMarkerRepository seedMarkerRepository;
+    private final EntertainmentRepository entertainmentRepository;
+    private final ArtistRepository artistRepository;
+    private final PromoterRepository promoterRepository;
+    private final VenueRepository venueRepository;
+    private final ConcertRepository concertRepository;
+    private final ConcertOptionRepository concertOptionRepository;
+    private final SeatRepository seatRepository;
+    private final SalesPolicyRepository salesPolicyRepository;
+    private final Environment environment;
+
+    @Value("${app.seed.create-admin-user:true}")
+    private boolean createAdminUser;
+
+    @Value("${app.seed.portfolio-enabled:false}")
+    private boolean portfolioSeedEnabled;
+
+    @Value("${app.seed.portfolio-marker-key:portfolio_seed_marker_v1}")
+    private String portfolioSeedMarkerKey;
+
+    @Value("${app.seed.portfolio-profiles:local,demo}")
+    private String portfolioSeedProfiles;
 
     @Override
     @Transactional
-    public void run(String... args) throws Exception {
-        // 1. 시스템 관리자 유저가 없는 경우에만 생성 (기동 확인용)
-        if (userRepository.count() == 0) {
-            userRepository.save(new User("admin", UserTier.VIP, UserRole.ADMIN));
-            log.info(">>>> Initial data created: Admin user registered.");
+    public void run(String... args) {
+        seedAdminUserIfNeeded();
+
+        if (!shouldRunPortfolioSeed()) {
+            log.info(">>>> Portfolio seed skipped. Set APP_PORTFOLIO_SEED_ENABLED=true on allowed profiles(local,demo) to enable.");
+            return;
         }
 
-        // 2. 추가적인 초기 데이터가 필요한 경우 아래에 구현하십시오.
-        log.info(">>>> System is ready. Use APIs for further data setup.");
+        String markerKey = normalizeRequired(portfolioSeedMarkerKey, "app.seed.portfolio-marker-key");
+        if (seedMarkerRepository.existsByMarkerKey(markerKey)) {
+            log.info(">>>> Portfolio seed skipped: marker already exists. marker={}", markerKey);
+            return;
+        }
+
+        seedPortfolioScenarios();
+        seedMarkerRepository.save(new SeedMarker(markerKey, LocalDateTime.now()));
+        log.info(">>>> Portfolio seed completed. marker={}", markerKey);
+    }
+
+    private void seedAdminUserIfNeeded() {
+        if (!createAdminUser) {
+            return;
+        }
+        if (userRepository.existsByUsername(ADMIN_USERNAME)) {
+            return;
+        }
+        userRepository.save(new User(ADMIN_USERNAME, UserTier.VIP, UserRole.ADMIN));
+        log.info(">>>> Initial data created: admin user registered.");
+    }
+
+    private boolean shouldRunPortfolioSeed() {
+        if (!portfolioSeedEnabled) {
+            return false;
+        }
+        Set<String> activeProfiles = resolveActiveProfiles();
+        Set<String> allowedProfiles = parseProfilesCsv(portfolioSeedProfiles);
+
+        if (allowedProfiles.isEmpty()) {
+            log.warn(">>>> Portfolio seed disabled: no allowed profiles configured.");
+            return false;
+        }
+
+        boolean profileMatched = activeProfiles.stream().anyMatch(allowedProfiles::contains);
+        if (!profileMatched) {
+            log.info(">>>> Portfolio seed disabled: activeProfiles={} allowedProfiles={}", activeProfiles, allowedProfiles);
+        }
+        return profileMatched;
+    }
+
+    private Set<String> resolveActiveProfiles() {
+        String[] active = environment.getActiveProfiles();
+        if (active.length == 0) {
+            active = environment.getDefaultProfiles();
+        }
+        Set<String> profiles = new LinkedHashSet<>();
+        for (String profile : active) {
+            String normalized = normalize(profile);
+            if (normalized != null) {
+                profiles.add(normalized.toLowerCase(Locale.ROOT));
+            }
+        }
+        return profiles;
+    }
+
+    private Set<String> parseProfilesCsv(String csv) {
+        Set<String> result = new LinkedHashSet<>();
+        if (csv == null) {
+            return result;
+        }
+        Arrays.stream(csv.split(","))
+                .map(this::normalize)
+                .filter(value -> value != null && !value.isEmpty())
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .forEach(result::add);
+        return result;
+    }
+
+    private void seedPortfolioScenarios() {
+        Promoter promoter = upsertPromoter(
+                "Portfolio Promoter",
+                "KR",
+                "https://portfolio-promoter.example.com"
+        );
+        Venue venue = upsertVenue(
+                "Portfolio Dome",
+                "Seoul",
+                "KR",
+                "240 Olympic-ro, Songpa-gu, Seoul"
+        );
+
+        LocalDateTime now = LocalDateTime.now();
+
+        seedPortfolioConcert(
+                "Portfolio Concert UNSCHEDULED",
+                "Portfolio Artist Unscheduled",
+                "Portfolio Entertainment Unscheduled",
+                promoter,
+                venue,
+                now.plusDays(10).withHour(20).withMinute(0).withSecond(0).withNano(0),
+                null,
+                false
+        );
+
+        seedPortfolioConcert(
+                "Portfolio Concert PREOPEN",
+                "Portfolio Artist Preopen",
+                "Portfolio Entertainment Preopen",
+                promoter,
+                venue,
+                now.plusDays(11).withHour(20).withMinute(0).withSecond(0).withNano(0),
+                now.plusHours(2),
+                false
+        );
+
+        seedPortfolioConcert(
+                "Portfolio Concert OPEN_SOON_1H",
+                "Portfolio Artist Soon1H",
+                "Portfolio Entertainment Soon1H",
+                promoter,
+                venue,
+                now.plusDays(12).withHour(20).withMinute(0).withSecond(0).withNano(0),
+                now.plusMinutes(40),
+                false
+        );
+
+        seedPortfolioConcert(
+                "Portfolio Concert OPEN_SOON_5M",
+                "Portfolio Artist Soon5M",
+                "Portfolio Entertainment Soon5M",
+                promoter,
+                venue,
+                now.plusDays(13).withHour(20).withMinute(0).withSecond(0).withNano(0),
+                now.plusMinutes(3),
+                false
+        );
+
+        seedPortfolioConcert(
+                "Portfolio Concert OPEN",
+                "Portfolio Artist Open",
+                "Portfolio Entertainment Open",
+                promoter,
+                venue,
+                now.plusDays(14).withHour(20).withMinute(0).withSecond(0).withNano(0),
+                now.minusMinutes(30),
+                false
+        );
+
+        seedPortfolioConcert(
+                "Portfolio Concert SOLD_OUT",
+                "Portfolio Artist SoldOut",
+                "Portfolio Entertainment SoldOut",
+                promoter,
+                venue,
+                now.plusDays(15).withHour(20).withMinute(0).withSecond(0).withNano(0),
+                now.minusMinutes(30),
+                true
+        );
+    }
+
+    private void seedPortfolioConcert(
+            String title,
+            String artistName,
+            String entertainmentName,
+            Promoter promoter,
+            Venue venue,
+            LocalDateTime concertDate,
+            LocalDateTime generalSaleStartAt,
+            boolean soldOut
+    ) {
+        String normalizedTitle = normalizeRequired(title, "title");
+        if (concertRepository.findByTitleIgnoreCase(normalizedTitle).isPresent()) {
+            log.info(">>>> Portfolio scenario already exists. title={}", normalizedTitle);
+            return;
+        }
+
+        Entertainment entertainment = upsertEntertainment(
+                entertainmentName,
+                "KR",
+                "https://" + normalizeHostname(entertainmentName) + ".example.com"
+        );
+        Artist artist = upsertArtist(
+                artistName,
+                entertainment,
+                artistName,
+                "K-POP",
+                LocalDate.of(2020, 1, 1)
+        );
+
+        Concert concert = concertRepository.save(new Concert(normalizedTitle, artist, promoter));
+        ConcertOption option = concertOptionRepository.save(
+                new ConcertOption(concert, concertDate, venue, DEFAULT_TICKET_PRICE_AMOUNT)
+        );
+
+        int seatCount = soldOut ? SOLD_OUT_SEAT_COUNT : DEFAULT_SEAT_COUNT;
+        List<Seat> seats = createSeats(option, seatCount);
+
+        if (generalSaleStartAt != null) {
+            salesPolicyRepository.save(
+                    SalesPolicy.create(
+                            concert,
+                            null,
+                            null,
+                            null,
+                            generalSaleStartAt,
+                            DEFAULT_MAX_RESERVATIONS_PER_USER
+                    )
+            );
+        }
+
+        if (soldOut) {
+            seats.forEach(Seat::reserve);
+            seatRepository.saveAll(seats);
+        }
+    }
+
+    private List<Seat> createSeats(ConcertOption option, int count) {
+        List<Seat> seats = new java.util.ArrayList<>(count);
+        for (int index = 1; index <= count; index++) {
+            seats.add(new Seat(option, "A-" + index));
+        }
+        return seatRepository.saveAll(seats);
+    }
+
+    private Entertainment upsertEntertainment(String name, String countryCode, String homepageUrl) {
+        String normalizedName = normalizeRequired(name, "entertainmentName");
+        return entertainmentRepository.findByNameIgnoreCase(normalizedName)
+                .map(existing -> {
+                    existing.rename(normalizedName);
+                    existing.updateMetadata(countryCode, homepageUrl);
+                    return existing;
+                })
+                .orElseGet(() -> entertainmentRepository.save(
+                        new Entertainment(normalizedName, countryCode, homepageUrl)
+                ));
+    }
+
+    private Artist upsertArtist(
+            String name,
+            Entertainment entertainment,
+            String displayName,
+            String genre,
+            LocalDate debutDate
+    ) {
+        String normalizedName = normalizeRequired(name, "artistName");
+        return artistRepository.findByNameIgnoreCase(normalizedName)
+                .map(existing -> {
+                    existing.rename(normalizedName);
+                    existing.updateProfile(entertainment, displayName, genre, debutDate);
+                    return existing;
+                })
+                .orElseGet(() -> artistRepository.save(
+                        new Artist(normalizedName, entertainment, displayName, genre, debutDate)
+                ));
+    }
+
+    private Promoter upsertPromoter(String name, String countryCode, String homepageUrl) {
+        String normalizedName = normalizeRequired(name, "promoterName");
+        return promoterRepository.findByNameIgnoreCase(normalizedName)
+                .map(existing -> {
+                    existing.update(normalizedName, countryCode, homepageUrl);
+                    return existing;
+                })
+                .orElseGet(() -> promoterRepository.save(
+                        new Promoter(normalizedName, countryCode, homepageUrl)
+                ));
+    }
+
+    private Venue upsertVenue(String name, String city, String countryCode, String address) {
+        String normalizedName = normalizeRequired(name, "venueName");
+        return venueRepository.findByNameIgnoreCase(normalizedName)
+                .map(existing -> {
+                    existing.update(normalizedName, city, countryCode, address);
+                    return existing;
+                })
+                .orElseGet(() -> venueRepository.save(
+                        new Venue(normalizedName, city, countryCode, address)
+                ));
+    }
+
+    private String normalizeHostname(String value) {
+        String normalized = normalizeRequired(value, "value");
+        return normalized.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("(^-+|-+$)", "");
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(fieldName + " is required");
+        }
+        return normalized;
     }
 }

--- a/src/main/java/com/ticketrush/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/com/ticketrush/domain/concert/repository/ConcertRepository.java
@@ -9,10 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ConcertRepository extends JpaRepository<Concert, Long> {
     boolean existsByArtistId(Long artistId);
     boolean existsByPromoterId(Long promoterId);
+    Optional<Concert> findByTitleIgnoreCase(String title);
 
     @Query("SELECT c FROM Concert c JOIN FETCH c.options")
     List<Concert> findAllWithOptions();

--- a/src/main/java/com/ticketrush/domain/seed/SeedMarker.java
+++ b/src/main/java/com/ticketrush/domain/seed/SeedMarker.java
@@ -1,0 +1,52 @@
+package com.ticketrush.domain.seed;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(
+        name = "seed_markers",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_seed_markers_marker_key", columnNames = {"marker_key"})
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeedMarker {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "marker_key", nullable = false, length = 120, unique = true)
+    private String markerKey;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public SeedMarker(String markerKey, LocalDateTime createdAt) {
+        this.markerKey = normalizeRequired(markerKey, "markerKey");
+        this.createdAt = createdAt == null ? LocalDateTime.now() : createdAt;
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + " is required");
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " is required");
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/ticketrush/domain/seed/SeedMarkerRepository.java
+++ b/src/main/java/com/ticketrush/domain/seed/SeedMarkerRepository.java
@@ -1,0 +1,7 @@
+package com.ticketrush.domain.seed;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeedMarkerRepository extends JpaRepository<SeedMarker, Long> {
+    boolean existsByMarkerKey(String markerKey);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,11 @@ app:
   payment:
     provider: ${APP_PAYMENT_PROVIDER:wallet}
     default-ticket-price-amount: 100000
+  seed:
+    create-admin-user: ${APP_SEED_ADMIN_ENABLED:true}
+    portfolio-enabled: ${APP_PORTFOLIO_SEED_ENABLED:false}
+    portfolio-marker-key: ${APP_PORTFOLIO_SEED_MARKER_KEY:portfolio_seed_marker_v1}
+    portfolio-profiles: ${APP_PORTFOLIO_SEED_PROFILES:local,demo}
   admin-console:
     minimum-role: USER
   push:

--- a/src/test/java/com/ticketrush/DataInitializerDataJpaTest.java
+++ b/src/test/java/com/ticketrush/DataInitializerDataJpaTest.java
@@ -1,0 +1,125 @@
+package com.ticketrush;
+
+import com.ticketrush.domain.artist.ArtistRepository;
+import com.ticketrush.domain.concert.repository.ConcertOptionRepository;
+import com.ticketrush.domain.concert.repository.ConcertRepository;
+import com.ticketrush.domain.concert.repository.SeatRepository;
+import com.ticketrush.domain.entertainment.EntertainmentRepository;
+import com.ticketrush.domain.promoter.PromoterRepository;
+import com.ticketrush.domain.reservation.repository.SalesPolicyRepository;
+import com.ticketrush.domain.seed.SeedMarkerRepository;
+import com.ticketrush.domain.user.UserRepository;
+import com.ticketrush.domain.venue.VenueRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class DataInitializerDataJpaTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SeedMarkerRepository seedMarkerRepository;
+    @Autowired
+    private EntertainmentRepository entertainmentRepository;
+    @Autowired
+    private ArtistRepository artistRepository;
+    @Autowired
+    private PromoterRepository promoterRepository;
+    @Autowired
+    private VenueRepository venueRepository;
+    @Autowired
+    private ConcertRepository concertRepository;
+    @Autowired
+    private ConcertOptionRepository concertOptionRepository;
+    @Autowired
+    private SeatRepository seatRepository;
+    @Autowired
+    private SalesPolicyRepository salesPolicyRepository;
+
+    @Test
+    @DisplayName("local profile + portfolio enabled 시 샘플 시드가 1회만 적용된다")
+    void seedsPortfolioOnlyOnce() {
+        DataInitializer initializer = buildInitializer("local", true, "portfolio_seed_marker_test", "local,demo");
+
+        initializer.run();
+
+        long userCountAfterFirst = userRepository.count();
+        long markerCountAfterFirst = seedMarkerRepository.count();
+        long concertCountAfterFirst = concertRepository.count();
+        long optionCountAfterFirst = concertOptionRepository.count();
+        long seatCountAfterFirst = seatRepository.count();
+        long policyCountAfterFirst = salesPolicyRepository.count();
+
+        assertThat(userRepository.existsByUsername("admin")).isTrue();
+        assertThat(markerCountAfterFirst).isEqualTo(1L);
+        assertThat(concertCountAfterFirst).isEqualTo(6L);
+        assertThat(optionCountAfterFirst).isEqualTo(6L);
+        assertThat(seatCountAfterFirst).isEqualTo(108L);
+        assertThat(policyCountAfterFirst).isEqualTo(5L);
+
+        initializer.run();
+
+        assertThat(userRepository.count()).isEqualTo(userCountAfterFirst);
+        assertThat(seedMarkerRepository.count()).isEqualTo(markerCountAfterFirst);
+        assertThat(entertainmentRepository.count()).isEqualTo(6L);
+        assertThat(artistRepository.count()).isEqualTo(6L);
+        assertThat(promoterRepository.count()).isEqualTo(1L);
+        assertThat(venueRepository.count()).isEqualTo(1L);
+        assertThat(concertRepository.count()).isEqualTo(concertCountAfterFirst);
+        assertThat(concertOptionRepository.count()).isEqualTo(optionCountAfterFirst);
+        assertThat(seatRepository.count()).isEqualTo(seatCountAfterFirst);
+        assertThat(salesPolicyRepository.count()).isEqualTo(policyCountAfterFirst);
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 profile에서는 portfolio 시드가 실행되지 않는다")
+    void skipsPortfolioSeedOnDisallowedProfile() {
+        DataInitializer initializer = buildInitializer("docker", true, "portfolio_seed_marker_test", "local,demo");
+
+        initializer.run();
+
+        assertThat(userRepository.existsByUsername("admin")).isTrue();
+        assertThat(seedMarkerRepository.count()).isZero();
+        assertThat(entertainmentRepository.count()).isZero();
+        assertThat(artistRepository.count()).isZero();
+        assertThat(promoterRepository.count()).isZero();
+        assertThat(venueRepository.count()).isZero();
+        assertThat(concertRepository.count()).isZero();
+        assertThat(concertOptionRepository.count()).isZero();
+        assertThat(seatRepository.count()).isZero();
+        assertThat(salesPolicyRepository.count()).isZero();
+    }
+
+    private DataInitializer buildInitializer(
+            String activeProfile,
+            boolean portfolioEnabled,
+            String markerKey,
+            String allowedProfiles
+    ) {
+        DataInitializer initializer = new DataInitializer(
+                userRepository,
+                seedMarkerRepository,
+                entertainmentRepository,
+                artistRepository,
+                promoterRepository,
+                venueRepository,
+                concertRepository,
+                concertOptionRepository,
+                seatRepository,
+                salesPolicyRepository,
+                new MockEnvironment().withProperty("spring.profiles.active", activeProfile)
+        );
+        ReflectionTestUtils.setField(initializer, "createAdminUser", true);
+        ReflectionTestUtils.setField(initializer, "portfolioSeedEnabled", portfolioEnabled);
+        ReflectionTestUtils.setField(initializer, "portfolioSeedMarkerKey", markerKey);
+        ReflectionTestUtils.setField(initializer, "portfolioSeedProfiles", allowedProfiles);
+        return initializer;
+    }
+}


### PR DESCRIPTION
## Summary
- add idempotent seed marker table/repository (`seed_markers`)
- extend `DataInitializer` with runtime-guarded portfolio seed scenarios
- gate portfolio seed by profile (`local,demo`) + env flags (`APP_PORTFOLIO_SEED_ENABLED`)
- keep admin seed separate via `APP_SEED_ADMIN_ENABLED`
- add Data JPA test to verify one-time seeding and profile guard
- document seed runtime knobs in README

## Validation
- ./gradlew clean compileJava
- ./gradlew test --tests '*DataInitializerDataJpaTest'
- ./gradlew test --tests '*ReservationStateMachineTest' --tests '*SeatSoftLockServiceImplTest' --tests '*ReservationLifecycleServiceIntegrationTest'

## Tracking
- closes #16
