### PR TITLE
refactor: phase2 boundary move services to application layer

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/AdminConcertController.java
+++ b/src/main/java/com/ticketrush/api/controller/AdminConcertController.java
@@ -8,7 +8,7 @@ import com.ticketrush.api.dto.admin.AdminConcertUpsertRequest;
 import com.ticketrush.api.dto.reservation.SalesPolicyResponse;
 import com.ticketrush.api.dto.reservation.SalesPolicyUpsertRequest;
 import com.ticketrush.domain.concert.service.ConcertService;
-import com.ticketrush.domain.reservation.service.SalesPolicyService;
+import com.ticketrush.application.reservation.service.SalesPolicyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/ticketrush/api/controller/ConcertController.java
+++ b/src/main/java/com/ticketrush/api/controller/ConcertController.java
@@ -8,7 +8,7 @@ import com.ticketrush.api.dto.SeatResponse;
 import com.ticketrush.api.dto.reservation.SalesPolicyResponse;
 import com.ticketrush.api.dto.reservation.SalesPolicyUpsertRequest;
 import com.ticketrush.domain.concert.service.ConcertService;
-import com.ticketrush.domain.reservation.service.SalesPolicyService;
+import com.ticketrush.application.reservation.service.SalesPolicyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/ticketrush/api/controller/PaymentWebhookController.java
+++ b/src/main/java/com/ticketrush/api/controller/PaymentWebhookController.java
@@ -2,7 +2,7 @@ package com.ticketrush.api.controller;
 
 import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
 import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;
-import com.ticketrush.domain.payment.webhook.PgReadyWebhookService;
+import com.ticketrush.application.payment.webhook.PgReadyWebhookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/ticketrush/api/controller/ReservationController.java
+++ b/src/main/java/com/ticketrush/api/controller/ReservationController.java
@@ -1,10 +1,10 @@
 package com.ticketrush.api.controller;
 
-import com.ticketrush.domain.reservation.service.ReservationService;
+import com.ticketrush.application.reservation.service.ReservationService;
 import com.ticketrush.domain.reservation.service.ReservationQueueService;
 import com.ticketrush.domain.reservation.service.AbuseAuditService;
 import com.ticketrush.domain.reservation.service.AdminRefundAuditService;
-import com.ticketrush.domain.reservation.service.ReservationLifecycleService;
+import com.ticketrush.application.reservation.service.ReservationLifecycleService;
 import com.ticketrush.domain.reservation.service.SeatSoftLockService;
 import com.ticketrush.domain.reservation.event.ReservationEvent;
 import com.ticketrush.domain.reservation.entity.AbuseAuditLog;

--- a/src/main/java/com/ticketrush/api/waitingqueue/WaitingQueueController.java
+++ b/src/main/java/com/ticketrush/api/waitingqueue/WaitingQueueController.java
@@ -4,7 +4,7 @@ import com.ticketrush.api.dto.waitingqueue.WaitingQueueSsePayload;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueStatus;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueRequest;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
-import com.ticketrush.domain.waitingqueue.service.WaitingQueueService;
+import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.sse.SsePushNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/ticketrush/application/payment/webhook/PgReadyWebhookService.java
+++ b/src/main/java/com/ticketrush/application/payment/webhook/PgReadyWebhookService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.payment.webhook;
+package com.ticketrush.application.payment.webhook;
 
 import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
 import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;

--- a/src/main/java/com/ticketrush/application/reservation/service/ReservationLifecycleService.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/ReservationLifecycleService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.reservation.service;
+package com.ticketrush.application.reservation.service;
 
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.api.dto.reservation.ReservationLifecycleResponse;

--- a/src/main/java/com/ticketrush/application/reservation/service/ReservationLifecycleServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/ReservationLifecycleServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.reservation.service;
+package com.ticketrush.application.reservation.service;
 
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.api.dto.reservation.ReservationLifecycleResponse;
@@ -13,6 +13,8 @@ import com.ticketrush.domain.reservation.port.outbound.ReservationSeatPort;
 import com.ticketrush.domain.reservation.port.outbound.ReservationUserPort;
 import com.ticketrush.domain.reservation.port.outbound.ReservationWaitingQueuePort;
 import com.ticketrush.domain.reservation.repository.ReservationRepository;
+import com.ticketrush.domain.reservation.service.AbuseAuditService;
+import com.ticketrush.domain.reservation.service.AdminRefundAuditService;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRole;
 import com.ticketrush.global.config.ReservationProperties;

--- a/src/main/java/com/ticketrush/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/ReservationService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.reservation.service;
+package com.ticketrush.application.reservation.service;
 
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.api.dto.ReservationResponse;

--- a/src/main/java/com/ticketrush/application/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/ReservationServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.reservation.service;
+package com.ticketrush.application.reservation.service;
 
 import com.ticketrush.domain.concert.entity.Seat;
 import com.ticketrush.domain.reservation.port.outbound.ReservationSeatPort;

--- a/src/main/java/com/ticketrush/application/reservation/service/SalesPolicyService.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/SalesPolicyService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.reservation.service;
+package com.ticketrush.application.reservation.service;
 
 import com.ticketrush.api.dto.reservation.SalesPolicyUpsertRequest;
 import com.ticketrush.domain.concert.entity.Seat;

--- a/src/main/java/com/ticketrush/application/reservation/service/SalesPolicyServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/SalesPolicyServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.reservation.service;
+package com.ticketrush.application.reservation.service;
 
 import com.ticketrush.api.dto.reservation.SalesPolicyUpsertRequest;
 import com.ticketrush.domain.concert.entity.Concert;

--- a/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueService.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.waitingqueue.service;
+package com.ticketrush.application.waitingqueue.service;
 
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
 

--- a/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.waitingqueue.service;
+package com.ticketrush.application.waitingqueue.service;
 
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueStatus;

--- a/src/main/java/com/ticketrush/domain/reservation/adapter/outbound/ReservationWaitingQueuePortAdapter.java
+++ b/src/main/java/com/ticketrush/domain/reservation/adapter/outbound/ReservationWaitingQueuePortAdapter.java
@@ -1,7 +1,7 @@
 package com.ticketrush.domain.reservation.adapter.outbound;
 
 import com.ticketrush.domain.reservation.port.outbound.ReservationWaitingQueuePort;
-import com.ticketrush.domain.waitingqueue.service.WaitingQueueService;
+import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/ticketrush/global/lock/RedissonLockFacade.java
+++ b/src/main/java/com/ticketrush/global/lock/RedissonLockFacade.java
@@ -1,6 +1,6 @@
 package com.ticketrush.global.lock;
 
-import com.ticketrush.domain.reservation.service.ReservationService;
+import com.ticketrush.application.reservation.service.ReservationService;
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.api.dto.ReservationResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ticketrush/global/messaging/KafkaReservationConsumer.java
+++ b/src/main/java/com/ticketrush/global/messaging/KafkaReservationConsumer.java
@@ -2,7 +2,7 @@ package com.ticketrush.global.messaging;
 
 import com.ticketrush.domain.reservation.event.ReservationEvent;
 import com.ticketrush.domain.reservation.service.ReservationQueueService;
-import com.ticketrush.domain.reservation.service.ReservationService;
+import com.ticketrush.application.reservation.service.ReservationService;
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.global.push.PushNotifier;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ticketrush/global/scheduler/ReservationLifecycleScheduler.java
+++ b/src/main/java/com/ticketrush/global/scheduler/ReservationLifecycleScheduler.java
@@ -1,6 +1,6 @@
 package com.ticketrush.global.scheduler;
 
-import com.ticketrush.domain.reservation.service.ReservationLifecycleService;
+import com.ticketrush.application.reservation.service.ReservationLifecycleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/ticketrush/global/scheduler/WaitingQueueScheduler.java
+++ b/src/main/java/com/ticketrush/global/scheduler/WaitingQueueScheduler.java
@@ -3,7 +3,7 @@ package com.ticketrush.global.scheduler;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueSsePayload;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueStatus;
-import com.ticketrush.domain.waitingqueue.service.WaitingQueueService;
+import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.push.PushNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/com/ticketrush/application/payment/webhook/PgReadyWebhookServiceTest.java
+++ b/src/test/java/com/ticketrush/application/payment/webhook/PgReadyWebhookServiceTest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.payment.webhook;
+package com.ticketrush.application.payment.webhook;
 
 import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
 import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;

--- a/src/test/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImplTest.java
+++ b/src/test/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.waitingqueue.service;
+package com.ticketrush.application.waitingqueue.service;
 
 import com.ticketrush.global.config.WaitingQueueProperties;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/ticketrush/domain/concert/service/ConcertExplorerIntegrationTest.java
+++ b/src/test/java/com/ticketrush/domain/concert/service/ConcertExplorerIntegrationTest.java
@@ -2,7 +2,7 @@ package com.ticketrush.domain.concert.service;
 
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.domain.concert.entity.Seat;
-import com.ticketrush.domain.reservation.service.ReservationService;
+import com.ticketrush.application.reservation.service.ReservationService;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;
 import com.ticketrush.domain.user.UserTier;

--- a/src/test/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceIntegrationTest.java
+++ b/src/test/java/com/ticketrush/domain/reservation/service/ReservationLifecycleServiceIntegrationTest.java
@@ -1,5 +1,8 @@
 package com.ticketrush.domain.reservation.service;
 
+import com.ticketrush.application.reservation.service.ReservationLifecycleService;
+import com.ticketrush.application.reservation.service.ReservationLifecycleServiceImpl;
+import com.ticketrush.application.reservation.service.SalesPolicyServiceImpl;
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.api.dto.reservation.ReservationLifecycleResponse;
 import com.ticketrush.domain.entertainment.Entertainment;
@@ -31,7 +34,7 @@ import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRole;
 import com.ticketrush.domain.user.UserTier;
 import com.ticketrush.domain.user.UserRepository;
-import com.ticketrush.domain.waitingqueue.service.WaitingQueueService;
+import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.cache.ConcertReadCacheEvictor;
 import com.ticketrush.global.config.AbuseGuardProperties;
 import com.ticketrush.global.config.PaymentProperties;

--- a/src/test/java/com/ticketrush/domain/reservation/service/동시성_테스트_1_낙관적_락.java
+++ b/src/test/java/com/ticketrush/domain/reservation/service/동시성_테스트_1_낙관적_락.java
@@ -1,5 +1,6 @@
 package com.ticketrush.domain.reservation.service;
 
+import com.ticketrush.application.reservation.service.ReservationService;
 import com.ticketrush.domain.concert.entity.Concert;
 import com.ticketrush.domain.concert.entity.ConcertOption;
 import com.ticketrush.domain.concert.entity.Seat;

--- a/src/test/java/com/ticketrush/domain/reservation/service/동시성_테스트_2_비관적_락.java
+++ b/src/test/java/com/ticketrush/domain/reservation/service/동시성_테스트_2_비관적_락.java
@@ -1,5 +1,6 @@
 package com.ticketrush.domain.reservation.service;
 
+import com.ticketrush.application.reservation.service.ReservationService;
 import com.ticketrush.domain.concert.entity.Concert;
 import com.ticketrush.domain.concert.entity.ConcertOption;
 import com.ticketrush.domain.concert.entity.Seat;

--- a/src/test/java/com/ticketrush/global/scheduler/ReservationLifecycleSchedulerTest.java
+++ b/src/test/java/com/ticketrush/global/scheduler/ReservationLifecycleSchedulerTest.java
@@ -1,6 +1,6 @@
 package com.ticketrush.global.scheduler;
 
-import com.ticketrush.domain.reservation.service.ReservationLifecycleService;
+import com.ticketrush.application.reservation.service.ReservationLifecycleService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/ticketrush/global/scheduler/WaitingQueueSchedulerTest.java
+++ b/src/test/java/com/ticketrush/global/scheduler/WaitingQueueSchedulerTest.java
@@ -1,7 +1,7 @@
 package com.ticketrush.global.scheduler;
 
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
-import com.ticketrush.domain.waitingqueue.service.WaitingQueueService;
+import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.config.WaitingQueueProperties;
 import com.ticketrush.global.push.PushNotifier;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- move reservation service classes (`ReservationService*`, `ReservationLifecycleService*`, `SalesPolicyService*`) from `domain` to `application`
- move waiting queue service (`WaitingQueueService*`) from `domain` to `application`
- move PG webhook service (`PgReadyWebhookService`) from `domain` to `application`
- update controller/scheduler/adapter/test imports and test package paths to new application boundaries

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests "com.ticketrush.global.scheduler.WaitingQueueSchedulerTest" --tests "com.ticketrush.application.payment.webhook.PgReadyWebhookServiceTest" --tests "com.ticketrush.application.waitingqueue.service.WaitingQueueServiceImplTest" --tests "com.ticketrush.domain.reservation.service.ReservationLifecycleServiceIntegrationTest"`

## Issue
- Refs #33
