### PR TITLE
refactor: phase3a decouple app services from api dto

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/PaymentWebhookController.java
+++ b/src/main/java/com/ticketrush/api/controller/PaymentWebhookController.java
@@ -2,6 +2,8 @@ package com.ticketrush.api.controller;
 
 import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
 import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;
+import com.ticketrush.application.payment.webhook.model.PgReadyWebhookCommand;
+import com.ticketrush.application.payment.webhook.model.PgReadyWebhookResult;
 import com.ticketrush.application.payment.webhook.PgReadyWebhookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,29 @@ public class PaymentWebhookController {
     public ResponseEntity<PgReadyWebhookResponse> receivePgReadyWebhook(
             @RequestBody PgReadyWebhookRequest request
     ) {
-        return ResponseEntity.accepted().body(pgReadyWebhookService.handle(request));
+        PgReadyWebhookResult result = pgReadyWebhookService.handle(
+                new PgReadyWebhookCommand(
+                        request.getProviderEventId(),
+                        request.getEventType(),
+                        request.getStatus(),
+                        request.getUserId(),
+                        request.getReservationId(),
+                        request.getAmount(),
+                        request.getIdempotencyKey(),
+                        request.getOccurredAt(),
+                        request.getSignature(),
+                        request.getMetadata()
+                )
+        );
+        return ResponseEntity.accepted().body(
+                new PgReadyWebhookResponse(
+                        result.getProvider(),
+                        result.getEventType(),
+                        result.getStatus(),
+                        result.getReservationId(),
+                        result.isAccepted(),
+                        result.getMessage()
+                )
+        );
     }
 }

--- a/src/main/java/com/ticketrush/api/waitingqueue/WaitingQueueController.java
+++ b/src/main/java/com/ticketrush/api/waitingqueue/WaitingQueueController.java
@@ -1,9 +1,12 @@
 package com.ticketrush.api.waitingqueue;
 
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueSsePayload;
-import com.ticketrush.api.dto.waitingqueue.WaitingQueueStatus;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueRequest;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueJoinCommand;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusQuery;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusResult;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusType;
 import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.sse.SsePushNotifier;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +30,10 @@ public class WaitingQueueController {
     @PostMapping("/join")
     public ResponseEntity<WaitingQueueResponse> join(@RequestBody WaitingQueueRequest request) {
         log.debug(">>>> [Incoming Request] join - userId: {}, concertId: {}", request.getUserId(), request.getConcertId());
-        return ResponseEntity.ok(waitingQueueService.join(request.getUserId(), request.getConcertId()));
+        WaitingQueueStatusResult result = waitingQueueService.join(
+                new WaitingQueueJoinCommand(request.getUserId(), request.getConcertId())
+        );
+        return ResponseEntity.ok(toApiResponse(result));
     }
 
     @GetMapping("/status")
@@ -35,7 +41,8 @@ public class WaitingQueueController {
             @RequestParam Long userId,
             @RequestParam Long concertId) {
         log.debug(">>>> [Incoming Request] status - userId: {}, concertId: {}", userId, concertId);
-        return ResponseEntity.ok(waitingQueueService.getStatus(userId, concertId));
+        WaitingQueueStatusResult result = waitingQueueService.getStatus(new WaitingQueueStatusQuery(userId, concertId));
+        return ResponseEntity.ok(toApiResponse(result));
     }
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -45,26 +52,35 @@ public class WaitingQueueController {
         log.debug(">>>> [Incoming Request] subscribe - userId: {}, concertId: {}", userId, concertId);
 
         SseEmitter emitter = ssePushNotifier.subscribeQueue(userId, concertId);
-        WaitingQueueResponse currentStatus = waitingQueueService.getStatus(userId, concertId);
-        Long activeTtlSeconds = WaitingQueueStatus.ACTIVE.name().equals(currentStatus.getStatus())
+        WaitingQueueStatusResult currentStatus = waitingQueueService.getStatus(new WaitingQueueStatusQuery(userId, concertId));
+        Long activeTtlSeconds = currentStatus.getStatus() == WaitingQueueStatusType.ACTIVE
                 ? waitingQueueService.getActiveTtlSeconds(userId)
                 : 0L;
 
         WaitingQueueSsePayload payload = WaitingQueueSsePayload.builder()
                 .userId(userId)
                 .concertId(concertId)
-                .status(currentStatus.getStatus())
+                .status(currentStatus.getStatus().name())
                 .rank(currentStatus.getRank())
                 .activeTtlSeconds(activeTtlSeconds)
                 .timestamp(Instant.now().toString())
                 .build();
 
-        if (WaitingQueueStatus.ACTIVE.name().equals(currentStatus.getStatus())) {
+        if (currentStatus.getStatus() == WaitingQueueStatusType.ACTIVE) {
             ssePushNotifier.sendQueueActivated(userId, concertId, payload);
         } else {
             ssePushNotifier.sendQueueRankUpdate(userId, concertId, payload);
         }
 
         return emitter;
+    }
+
+    private WaitingQueueResponse toApiResponse(WaitingQueueStatusResult result) {
+        return WaitingQueueResponse.builder()
+                .userId(result.getUserId())
+                .concertId(result.getConcertId())
+                .status(result.getStatus().name())
+                .rank(result.getRank())
+                .build();
     }
 }

--- a/src/main/java/com/ticketrush/application/payment/webhook/PgReadyWebhookService.java
+++ b/src/main/java/com/ticketrush/application/payment/webhook/PgReadyWebhookService.java
@@ -1,7 +1,7 @@
 package com.ticketrush.application.payment.webhook;
 
-import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
-import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;
+import com.ticketrush.application.payment.webhook.model.PgReadyWebhookCommand;
+import com.ticketrush.application.payment.webhook.model.PgReadyWebhookResult;
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
 import com.ticketrush.domain.payment.entity.PaymentTransactionType;
@@ -33,11 +33,11 @@ public class PgReadyWebhookService {
     private static final String STATUS_FAILED = "FAILED";
 
     @Transactional
-    public PgReadyWebhookResponse handle(PgReadyWebhookRequest request) {
-        String eventType = normalizeUpper(request.getEventType());
-        String status = normalizeUpper(request.getStatus());
-        Long reservationId = request.getReservationId();
-        String providerEventId = normalizeRaw(request.getProviderEventId());
+    public PgReadyWebhookResult handle(PgReadyWebhookCommand command) {
+        String eventType = normalizeUpper(command.getEventType());
+        String status = normalizeUpper(command.getStatus());
+        Long reservationId = command.getReservationId();
+        String providerEventId = normalizeRaw(command.getProviderEventId());
 
         if (!StringUtils.hasText(eventType)) {
             throw new IllegalArgumentException("eventType is required");
@@ -53,7 +53,7 @@ public class PgReadyWebhookService {
             return acceptedResponse(eventType, status, reservationId, "ignored unsupported eventType");
         }
 
-        PaymentTransaction paymentTransaction = resolvePaymentTransaction(request, reservationId);
+        PaymentTransaction paymentTransaction = resolvePaymentTransaction(command, reservationId);
         if (STATUS_APPROVED.equals(status)) {
             handleApproved(paymentTransaction, reservationId, providerEventId);
             return acceptedResponse(eventType, status, reservationId, "applied approved");
@@ -74,8 +74,8 @@ public class PgReadyWebhookService {
         return acceptedResponse(eventType, status, reservationId, "ignored unsupported status");
     }
 
-    private PaymentTransaction resolvePaymentTransaction(PgReadyWebhookRequest request, Long reservationId) {
-        String idempotencyKey = normalizeRaw(request.getIdempotencyKey());
+    private PaymentTransaction resolvePaymentTransaction(PgReadyWebhookCommand command, Long reservationId) {
+        String idempotencyKey = normalizeRaw(command.getIdempotencyKey());
         if (StringUtils.hasText(idempotencyKey)) {
             return paymentTransactionRepository.findByIdempotencyKey(idempotencyKey)
                     .orElseThrow(() -> new IllegalStateException("Payment transaction not found. idempotencyKey=" + idempotencyKey));
@@ -128,8 +128,8 @@ public class PgReadyWebhookService {
         paymentTransaction.markFailed(buildDescription("PG_READY_PAYMENT_FAILED", providerEventId));
     }
 
-    private PgReadyWebhookResponse acceptedResponse(String eventType, String status, Long reservationId, String message) {
-        return new PgReadyWebhookResponse("pg-ready", eventType, status, reservationId, true, message);
+    private PgReadyWebhookResult acceptedResponse(String eventType, String status, Long reservationId, String message) {
+        return new PgReadyWebhookResult("pg-ready", eventType, status, reservationId, true, message);
     }
 
     private String buildDescription(String base, String providerEventId) {

--- a/src/main/java/com/ticketrush/application/payment/webhook/model/PgReadyWebhookCommand.java
+++ b/src/main/java/com/ticketrush/application/payment/webhook/model/PgReadyWebhookCommand.java
@@ -1,0 +1,21 @@
+package com.ticketrush.application.payment.webhook.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class PgReadyWebhookCommand {
+    private String providerEventId;
+    private String eventType;
+    private String status;
+    private Long userId;
+    private Long reservationId;
+    private Long amount;
+    private String idempotencyKey;
+    private String occurredAt;
+    private String signature;
+    private Map<String, Object> metadata;
+}

--- a/src/main/java/com/ticketrush/application/payment/webhook/model/PgReadyWebhookResult.java
+++ b/src/main/java/com/ticketrush/application/payment/webhook/model/PgReadyWebhookResult.java
@@ -1,0 +1,15 @@
+package com.ticketrush.application.payment.webhook.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PgReadyWebhookResult {
+    private String provider;
+    private String eventType;
+    private String status;
+    private Long reservationId;
+    private boolean accepted;
+    private String message;
+}

--- a/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueJoinCommand.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueJoinCommand.java
@@ -1,0 +1,13 @@
+package com.ticketrush.application.waitingqueue.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class WaitingQueueJoinCommand {
+    private final Long userId;
+    private final Long concertId;
+}

--- a/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueStatusQuery.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueStatusQuery.java
@@ -1,0 +1,13 @@
+package com.ticketrush.application.waitingqueue.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class WaitingQueueStatusQuery {
+    private final Long userId;
+    private final Long concertId;
+}

--- a/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueStatusResult.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueStatusResult.java
@@ -1,0 +1,17 @@
+package com.ticketrush.application.waitingqueue.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WaitingQueueStatusResult {
+    private Long userId;
+    private Long concertId;
+    private WaitingQueueStatusType status;
+    private Long rank;
+}

--- a/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueStatusType.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/model/WaitingQueueStatusType.java
@@ -1,0 +1,8 @@
+package com.ticketrush.application.waitingqueue.model;
+
+public enum WaitingQueueStatusType {
+    WAITING,
+    ACTIVE,
+    REJECTED,
+    NONE
+}

--- a/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueService.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueService.java
@@ -1,12 +1,14 @@
 package com.ticketrush.application.waitingqueue.service;
 
-import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueJoinCommand;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusQuery;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusResult;
 
 import java.util.List;
 
 public interface WaitingQueueService {
-    WaitingQueueResponse join(Long userId, Long concertId);
-    WaitingQueueResponse getStatus(Long userId, Long concertId);
+    WaitingQueueStatusResult join(WaitingQueueJoinCommand command);
+    WaitingQueueStatusResult getStatus(WaitingQueueStatusQuery query);
     List<Long> activateUsers(Long concertId, long count);
     Long getActiveTtlSeconds(Long userId);
 }

--- a/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImpl.java
@@ -1,7 +1,9 @@
 package com.ticketrush.application.waitingqueue.service;
 
-import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
-import com.ticketrush.api.dto.waitingqueue.WaitingQueueStatus;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueJoinCommand;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusQuery;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusResult;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
@@ -83,9 +85,9 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
     }
 
     @Override
-    public WaitingQueueResponse join(Long userId, Long concertId) {
-        String queueKey = properties.getQueueKeyPrefix() + concertId;
-        String userIdStr = String.valueOf(userId);
+    public WaitingQueueStatusResult join(WaitingQueueJoinCommand command) {
+        String queueKey = properties.getQueueKeyPrefix() + command.getConcertId();
+        String userIdStr = String.valueOf(command.getUserId());
         String activeKey = properties.getActiveKeyPrefix() + userIdStr;
 
         // Redis round trip을 줄이기 위해 join/throttling/rank 계산을 Lua 스크립트로 원자 처리한다.
@@ -97,42 +99,42 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
                 String.valueOf(properties.getMaxQueueSize())
         );
         if (scriptResult == null || scriptResult.size() < 2) {
-            return getStatus(userId, concertId);
+            return getStatus(new WaitingQueueStatusQuery(command.getUserId(), command.getConcertId()));
         }
 
         long resultCode = toLong(scriptResult.get(0), JOIN_RESULT_UNKNOWN);
         long rank = toLong(scriptResult.get(1), -1L);
 
         if (resultCode == JOIN_RESULT_ACTIVE) {
-            return buildResponse(userId, concertId, WaitingQueueStatus.ACTIVE.name(), 0L);
+            return buildResponse(command.getUserId(), command.getConcertId(), WaitingQueueStatusType.ACTIVE, 0L);
         }
         if (resultCode == JOIN_RESULT_REJECTED) {
-            return buildResponse(userId, concertId, WaitingQueueStatus.REJECTED.name(), -1L);
+            return buildResponse(command.getUserId(), command.getConcertId(), WaitingQueueStatusType.REJECTED, -1L);
         }
         if (resultCode == JOIN_RESULT_WAITING) {
-            return buildResponse(userId, concertId, WaitingQueueStatus.WAITING.name(), rank > 0 ? rank : 1L);
+            return buildResponse(command.getUserId(), command.getConcertId(), WaitingQueueStatusType.WAITING, rank > 0 ? rank : 1L);
         }
 
-        return getStatus(userId, concertId);
+        return getStatus(new WaitingQueueStatusQuery(command.getUserId(), command.getConcertId()));
     }
 
     @Override
-    public WaitingQueueResponse getStatus(Long userId, Long concertId) {
-        String userIdStr = String.valueOf(userId);
+    public WaitingQueueStatusResult getStatus(WaitingQueueStatusQuery query) {
+        String userIdStr = String.valueOf(query.getUserId());
 
         // 1. 활성 상태 확인
         if (Boolean.TRUE.equals(redisTemplate.hasKey(properties.getActiveKeyPrefix() + userIdStr))) {
-            return buildResponse(userId, concertId, WaitingQueueStatus.ACTIVE.name(), 0L);
+            return buildResponse(query.getUserId(), query.getConcertId(), WaitingQueueStatusType.ACTIVE, 0L);
         }
 
         // 2. 대기 순번 조회
-        String queueKey = properties.getQueueKeyPrefix() + concertId;
+        String queueKey = properties.getQueueKeyPrefix() + query.getConcertId();
         Long rank = redisTemplate.opsForZSet().rank(queueKey, userIdStr);
 
         return buildResponse(
-                userId,
-                concertId,
-                rank != null ? WaitingQueueStatus.WAITING.name() : WaitingQueueStatus.NONE.name(),
+                query.getUserId(),
+                query.getConcertId(),
+                rank != null ? WaitingQueueStatusType.WAITING : WaitingQueueStatusType.NONE,
                 rank != null ? rank + 1 : -1L // 0-based rank이므로 +1
         );
     }
@@ -174,8 +176,8 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
         return (ttl != null && ttl > 0) ? ttl : 0L;
     }
 
-    private WaitingQueueResponse buildResponse(Long userId, Long concertId, String status, Long rank) {
-        return WaitingQueueResponse.builder()
+    private WaitingQueueStatusResult buildResponse(Long userId, Long concertId, WaitingQueueStatusType status, Long rank) {
+        return WaitingQueueStatusResult.builder()
                 .userId(userId)
                 .concertId(concertId)
                 .status(status)

--- a/src/main/java/com/ticketrush/global/scheduler/WaitingQueueScheduler.java
+++ b/src/main/java/com/ticketrush/global/scheduler/WaitingQueueScheduler.java
@@ -1,8 +1,9 @@
 package com.ticketrush.global.scheduler;
 
-import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
 import com.ticketrush.api.dto.waitingqueue.WaitingQueueSsePayload;
-import com.ticketrush.api.dto.waitingqueue.WaitingQueueStatus;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusQuery;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusResult;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusType;
 import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.push.PushNotifier;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class WaitingQueueScheduler {
             pushNotifier.sendQueueActivated(
                     userId,
                     concertId,
-                    buildPayload(userId, concertId, WaitingQueueStatus.ACTIVE.name(), 0L, activeTtlSeconds)
+                    buildPayload(userId, concertId, WaitingQueueStatusType.ACTIVE.name(), 0L, activeTtlSeconds)
             );
         }
 
@@ -70,19 +71,19 @@ public class WaitingQueueScheduler {
                 continue;
             }
 
-            WaitingQueueResponse status = waitingQueueService.getStatus(userId, concertId);
-            Long activeTtlSeconds = WaitingQueueStatus.ACTIVE.name().equals(status.getStatus())
+            WaitingQueueStatusResult status = waitingQueueService.getStatus(new WaitingQueueStatusQuery(userId, concertId));
+            Long activeTtlSeconds = status.getStatus() == WaitingQueueStatusType.ACTIVE
                     ? waitingQueueService.getActiveTtlSeconds(userId)
                     : 0L;
             WaitingQueueSsePayload payload = buildPayload(
                     userId,
                     concertId,
-                    status.getStatus(),
+                    status.getStatus().name(),
                     status.getRank(),
                     activeTtlSeconds
             );
 
-            if (WaitingQueueStatus.ACTIVE.name().equals(status.getStatus())) {
+            if (status.getStatus() == WaitingQueueStatusType.ACTIVE) {
                 pushNotifier.sendQueueActivated(userId, concertId, payload);
             } else {
                 pushNotifier.sendQueueRankUpdate(userId, concertId, payload);

--- a/src/test/java/com/ticketrush/application/payment/webhook/PgReadyWebhookServiceTest.java
+++ b/src/test/java/com/ticketrush/application/payment/webhook/PgReadyWebhookServiceTest.java
@@ -1,7 +1,7 @@
 package com.ticketrush.application.payment.webhook;
 
-import com.ticketrush.api.dto.payment.PgReadyWebhookRequest;
-import com.ticketrush.api.dto.payment.PgReadyWebhookResponse;
+import com.ticketrush.application.payment.webhook.model.PgReadyWebhookCommand;
+import com.ticketrush.application.payment.webhook.model.PgReadyWebhookResult;
 import com.ticketrush.domain.entertainment.Entertainment;
 import com.ticketrush.domain.entertainment.EntertainmentRepository;
 import com.ticketrush.domain.artist.Artist;
@@ -103,7 +103,7 @@ class PgReadyWebhookServiceTest {
                 )
         );
 
-        PgReadyWebhookResponse response = pgReadyWebhookService.handle(new PgReadyWebhookRequest(
+        PgReadyWebhookResult response = pgReadyWebhookService.handle(new PgReadyWebhookCommand(
                 "evt-approved-1",
                 "PAYMENT",
                 "APPROVED",
@@ -152,7 +152,7 @@ class PgReadyWebhookServiceTest {
                 )
         );
 
-        PgReadyWebhookResponse response = pgReadyWebhookService.handle(new PgReadyWebhookRequest(
+        PgReadyWebhookResult response = pgReadyWebhookService.handle(new PgReadyWebhookCommand(
                 "evt-failed-1",
                 "PAYMENT",
                 "FAILED",
@@ -180,7 +180,7 @@ class PgReadyWebhookServiceTest {
 
     @Test
     void handle_shouldIgnoreUnsupportedEventType() {
-        PgReadyWebhookResponse response = pgReadyWebhookService.handle(new PgReadyWebhookRequest(
+        PgReadyWebhookResult response = pgReadyWebhookService.handle(new PgReadyWebhookCommand(
                 "evt-unsupported",
                 "REFUND",
                 "APPROVED",

--- a/src/test/java/com/ticketrush/global/scheduler/WaitingQueueSchedulerTest.java
+++ b/src/test/java/com/ticketrush/global/scheduler/WaitingQueueSchedulerTest.java
@@ -1,6 +1,8 @@
 package com.ticketrush.global.scheduler;
 
-import com.ticketrush.api.dto.waitingqueue.WaitingQueueResponse;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusQuery;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusResult;
+import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusType;
 import com.ticketrush.application.waitingqueue.service.WaitingQueueService;
 import com.ticketrush.global.config.WaitingQueueProperties;
 import com.ticketrush.global.push.PushNotifier;
@@ -53,11 +55,11 @@ class WaitingQueueSchedulerTest {
         when(waitingQueueService.activateUsers(1L, 10L)).thenReturn(List.of(101L));
         when(waitingQueueService.getActiveTtlSeconds(101L)).thenReturn(280L);
         when(pushNotifier.getSubscribedQueueUsers(1L)).thenReturn(Set.of(101L, 102L));
-        when(waitingQueueService.getStatus(102L, 1L)).thenReturn(
-                WaitingQueueResponse.builder()
+        when(waitingQueueService.getStatus(new WaitingQueueStatusQuery(102L, 1L))).thenReturn(
+                WaitingQueueStatusResult.builder()
                         .userId(102L)
                         .concertId(1L)
-                        .status("WAITING")
+                        .status(WaitingQueueStatusType.WAITING)
                         .rank(5L)
                         .build()
         );
@@ -67,7 +69,7 @@ class WaitingQueueSchedulerTest {
         verify(schedulerLockService).runWithLock(eq("scheduler:waiting-queue:activate:1"), any());
         verify(pushNotifier).sendQueueActivated(eq(101L), eq(1L), any());
         verify(pushNotifier).sendQueueRankUpdate(eq(102L), eq(1L), any());
-        verify(waitingQueueService, never()).getStatus(101L, 1L);
+        verify(waitingQueueService, never()).getStatus(new WaitingQueueStatusQuery(101L, 1L));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- introduce application-level command/result models for waitingqueue and pg-ready webhook
- replace direct API DTO usage in application services (`WaitingQueueService*`, `PgReadyWebhookService`)
- move API mapping responsibility to controllers (`WaitingQueueController`, `PaymentWebhookController`)
- update scheduler and tests to consume application models

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests "com.ticketrush.global.scheduler.WaitingQueueSchedulerTest" --tests "com.ticketrush.application.waitingqueue.service.WaitingQueueServiceImplTest" --tests "com.ticketrush.application.payment.webhook.PgReadyWebhookServiceTest"`

## Issue
- Refs #33
