### PR TITLE
test: add archunit guardrail + verify CI gate

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,27 @@
+name: verify
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Ensure executable bits
+        run: chmod +x ./gradlew
+
+      - name: Run architecture guardrail tests
+        run: ./gradlew --no-daemon test --tests 'com.ticketrush.architecture.LayerDependencyArchTest'

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
-import jakarta.persistence.Entity;
+import org.springframework.web.bind.annotation.RestController;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
@@ -12,14 +12,20 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 class LayerDependencyArchTest {
 
     @ArchTest
-    static final ArchRule entities_should_not_depend_on_api_layer =
+    static final ArchRule domain_should_not_depend_on_api_layer =
             noClasses()
-                    .that().areAnnotatedWith(Entity.class)
+                    .that().resideInAPackage("com.ticketrush.domain..")
                     .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.api..");
 
     @ArchTest
-    static final ArchRule controllers_should_not_depend_on_repository_directly =
+    static final ArchRule application_should_not_depend_on_api_layer =
             noClasses()
-                    .that().resideInAPackage("com.ticketrush.api.controller..")
+                    .that().resideInAPackage("com.ticketrush.application..")
+                    .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.api..");
+
+    @ArchTest
+    static final ArchRule rest_controllers_should_not_depend_on_repository_directly =
+            noClasses()
+                    .that().areAnnotatedWith(RestController.class)
                     .should().dependOnClassesThat().haveSimpleNameEndingWith("Repository");
 }


### PR DESCRIPTION
## Summary
- strengthen `LayerDependencyArchTest` rules
  - block `domain -> api` package dependencies
  - block `application -> api` package dependencies
  - block direct `RestController -> *Repository` dependencies
- add `.github/workflows/verify.yml` to run ArchUnit guardrails on every PR/push to `main`
- set main branch protection required status check to `verify` (strict)

## Verification
- `./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest'`
- `./gradlew compileJava compileTestJava --no-daemon`

Closes #33
