### PR TITLE
refactor: decouple reservation controller from domain reservation types

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/ReservationController.java
+++ b/src/main/java/com/ticketrush/api/controller/ReservationController.java
@@ -2,16 +2,18 @@ package com.ticketrush.api.controller;
 
 import com.ticketrush.application.reservation.model.ReservationCreateCommand;
 import com.ticketrush.application.reservation.model.ReservationLifecycleResult;
+import com.ticketrush.application.reservation.model.ReservationQueueLockType;
 import com.ticketrush.application.reservation.model.ReservationResult;
+import com.ticketrush.application.reservation.model.AbuseAuditActionType;
+import com.ticketrush.application.reservation.model.AbuseAuditResultType;
+import com.ticketrush.application.reservation.model.AbuseAuditReasonType;
+import com.ticketrush.application.reservation.model.AdminRefundAuditResultType;
 import com.ticketrush.application.reservation.service.ReservationService;
 import com.ticketrush.application.reservation.service.ReservationQueueService;
 import com.ticketrush.application.reservation.service.AbuseAuditService;
 import com.ticketrush.application.reservation.service.AdminRefundAuditService;
 import com.ticketrush.application.reservation.service.ReservationLifecycleService;
 import com.ticketrush.application.reservation.service.SeatSoftLockService;
-import com.ticketrush.domain.reservation.event.ReservationEvent;
-import com.ticketrush.domain.reservation.entity.AbuseAuditLog;
-import com.ticketrush.domain.reservation.entity.AdminRefundAuditLog;
 import com.ticketrush.global.lock.RedissonLockFacade;
 import com.ticketrush.global.messaging.KafkaReservationProducer;
 import com.ticketrush.global.sse.SsePushNotifier;
@@ -85,7 +87,7 @@ public class ReservationController {
      */
     @PostMapping("/v4-opt/queue-polling")
     public ResponseEntity<Map<String, String>> createPollingOptimisticReservation(@RequestBody ReservationRequest request) {
-        return enqueue(request, ReservationEvent.LockType.OPTIMISTIC);
+        return enqueue(request, ReservationQueueLockType.OPTIMISTIC);
     }
 
     /**
@@ -93,7 +95,7 @@ public class ReservationController {
      */
     @PostMapping("/v4-pes/queue-polling")
     public ResponseEntity<Map<String, String>> createPollingPessimisticReservation(@RequestBody ReservationRequest request) {
-        return enqueue(request, ReservationEvent.LockType.PESSIMISTIC);
+        return enqueue(request, ReservationQueueLockType.PESSIMISTIC);
     }
 
     /**
@@ -122,7 +124,7 @@ public class ReservationController {
      */
     @PostMapping("/v5-opt/queue-sse")
     public ResponseEntity<Map<String, String>> createSseOptimisticReservation(@RequestBody ReservationRequest request) {
-        return enqueue(request, ReservationEvent.LockType.OPTIMISTIC);
+        return enqueue(request, ReservationQueueLockType.OPTIMISTIC);
     }
 
     /**
@@ -194,9 +196,9 @@ public class ReservationController {
      */
     @GetMapping("/v6/audit/abuse")
     public ResponseEntity<List<AbuseAuditResponse>> getAbuseAudits(
-            @RequestParam(required = false) AbuseAuditLog.AuditAction action,
-            @RequestParam(required = false) AbuseAuditLog.AuditResult result,
-            @RequestParam(required = false) AbuseAuditLog.AuditReason reason,
+            @RequestParam(required = false) AbuseAuditActionType action,
+            @RequestParam(required = false) AbuseAuditResultType result,
+            @RequestParam(required = false) AbuseAuditReasonType reason,
             @RequestParam(required = false) Long userId,
             @RequestParam(required = false) Long concertId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fromAt,
@@ -352,9 +354,9 @@ public class ReservationController {
      */
     @GetMapping("/v7/audit/abuse")
     public ResponseEntity<List<AbuseAuditResponse>> getAbuseAuditsV7(
-            @RequestParam(required = false) AbuseAuditLog.AuditAction action,
-            @RequestParam(required = false) AbuseAuditLog.AuditResult result,
-            @RequestParam(required = false) AbuseAuditLog.AuditReason reason,
+            @RequestParam(required = false) AbuseAuditActionType action,
+            @RequestParam(required = false) AbuseAuditResultType result,
+            @RequestParam(required = false) AbuseAuditReasonType reason,
             @RequestParam(required = false) Long userId,
             @RequestParam(required = false) Long concertId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fromAt,
@@ -377,7 +379,7 @@ public class ReservationController {
     public ResponseEntity<List<AdminRefundAuditResponse>> getAdminRefundAuditsV7(
             @RequestParam(required = false) Long reservationId,
             @RequestParam(required = false) Long actorUserId,
-            @RequestParam(required = false) AdminRefundAuditLog.AuditResult result,
+            @RequestParam(required = false) AdminRefundAuditResultType result,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fromAt,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime toAt,
             @RequestParam(required = false) Integer limit
@@ -390,9 +392,9 @@ public class ReservationController {
         );
     }
 
-    private ResponseEntity<Map<String, String>> enqueue(ReservationRequest request, ReservationEvent.LockType lockType) {
+    private ResponseEntity<Map<String, String>> enqueue(ReservationRequest request, ReservationQueueLockType lockType) {
         queueService.setStatus(request.getUserId(), request.getSeatId(), "PENDING");
-        kafkaProducer.send(ReservationEvent.of(request.getUserId(), request.getSeatId(), lockType));
+        kafkaProducer.send(request.getUserId(), request.getSeatId(), lockType);
         return ResponseEntity.accepted().body(Map.of(
             "message", "Reservation request enqueued",
             "strategy", lockType.name()

--- a/src/main/java/com/ticketrush/api/dto/reservation/AbuseAuditResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/reservation/AbuseAuditResponse.java
@@ -1,6 +1,6 @@
 package com.ticketrush.api.dto.reservation;
 
-import com.ticketrush.domain.reservation.entity.AbuseAuditLog;
+import com.ticketrush.application.reservation.model.AbuseAuditRecord;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,20 +24,20 @@ public class AbuseAuditResponse {
     private String detailMessage;
     private LocalDateTime occurredAt;
 
-    public static AbuseAuditResponse from(AbuseAuditLog log) {
+    public static AbuseAuditResponse from(AbuseAuditRecord log) {
         return new AbuseAuditResponse(
-                log.getId(),
-                log.getAction().name(),
-                log.getResult().name(),
-                log.getReason().name(),
-                log.getUserId(),
-                log.getConcertId(),
-                log.getSeatId(),
-                log.getReservationId(),
-                log.getRequestFingerprint(),
-                log.getDeviceFingerprint(),
-                log.getDetailMessage(),
-                log.getOccurredAt()
+                log.id(),
+                log.action().name(),
+                log.result().name(),
+                log.reason().name(),
+                log.userId(),
+                log.concertId(),
+                log.seatId(),
+                log.reservationId(),
+                log.requestFingerprint(),
+                log.deviceFingerprint(),
+                log.detailMessage(),
+                log.occurredAt()
         );
     }
 }

--- a/src/main/java/com/ticketrush/api/dto/reservation/AdminRefundAuditResponse.java
+++ b/src/main/java/com/ticketrush/api/dto/reservation/AdminRefundAuditResponse.java
@@ -1,6 +1,7 @@
 package com.ticketrush.api.dto.reservation;
 
-import com.ticketrush.domain.reservation.entity.AdminRefundAuditLog;
+import com.ticketrush.application.reservation.model.AdminRefundAuditRecord;
+import com.ticketrush.application.reservation.model.AdminRefundAuditResultType;
 import com.ticketrush.domain.user.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,20 +18,20 @@ public class AdminRefundAuditResponse {
     private Long targetUserId;
     private Long actorUserId;
     private UserRole actorRole;
-    private AdminRefundAuditLog.AuditResult result;
+    private AdminRefundAuditResultType result;
     private String detailMessage;
     private LocalDateTime occurredAt;
 
-    public static AdminRefundAuditResponse from(AdminRefundAuditLog auditLog) {
+    public static AdminRefundAuditResponse from(AdminRefundAuditRecord auditLog) {
         return new AdminRefundAuditResponse(
-                auditLog.getId(),
-                auditLog.getReservationId(),
-                auditLog.getTargetUserId(),
-                auditLog.getActorUserId(),
-                auditLog.getActorRole(),
-                auditLog.getResult(),
-                auditLog.getDetailMessage(),
-                auditLog.getOccurredAt()
+                auditLog.id(),
+                auditLog.reservationId(),
+                auditLog.targetUserId(),
+                auditLog.actorUserId(),
+                auditLog.actorRole(),
+                auditLog.result(),
+                auditLog.detailMessage(),
+                auditLog.occurredAt()
         );
     }
 }

--- a/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditActionType.java
+++ b/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditActionType.java
@@ -1,0 +1,5 @@
+package com.ticketrush.application.reservation.model;
+
+public enum AbuseAuditActionType {
+    HOLD_CREATE
+}

--- a/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditReasonType.java
+++ b/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditReasonType.java
@@ -1,0 +1,8 @@
+package com.ticketrush.application.reservation.model;
+
+public enum AbuseAuditReasonType {
+    NONE,
+    RATE_LIMIT_EXCEEDED,
+    DUPLICATE_REQUEST_FINGERPRINT,
+    DEVICE_FINGERPRINT_MULTI_ACCOUNT
+}

--- a/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditRecord.java
+++ b/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditRecord.java
@@ -1,0 +1,19 @@
+package com.ticketrush.application.reservation.model;
+
+import java.time.LocalDateTime;
+
+public record AbuseAuditRecord(
+        Long id,
+        AbuseAuditActionType action,
+        AbuseAuditResultType result,
+        AbuseAuditReasonType reason,
+        Long userId,
+        Long concertId,
+        Long seatId,
+        Long reservationId,
+        String requestFingerprint,
+        String deviceFingerprint,
+        String detailMessage,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditResultType.java
+++ b/src/main/java/com/ticketrush/application/reservation/model/AbuseAuditResultType.java
@@ -1,0 +1,6 @@
+package com.ticketrush.application.reservation.model;
+
+public enum AbuseAuditResultType {
+    ALLOWED,
+    BLOCKED
+}

--- a/src/main/java/com/ticketrush/application/reservation/model/AdminRefundAuditRecord.java
+++ b/src/main/java/com/ticketrush/application/reservation/model/AdminRefundAuditRecord.java
@@ -1,0 +1,17 @@
+package com.ticketrush.application.reservation.model;
+
+import com.ticketrush.domain.user.UserRole;
+
+import java.time.LocalDateTime;
+
+public record AdminRefundAuditRecord(
+        Long id,
+        Long reservationId,
+        Long targetUserId,
+        Long actorUserId,
+        UserRole actorRole,
+        AdminRefundAuditResultType result,
+        String detailMessage,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/ticketrush/application/reservation/model/AdminRefundAuditResultType.java
+++ b/src/main/java/com/ticketrush/application/reservation/model/AdminRefundAuditResultType.java
@@ -1,0 +1,7 @@
+package com.ticketrush.application.reservation.model;
+
+public enum AdminRefundAuditResultType {
+    SUCCESS,
+    DENIED,
+    FAILED
+}

--- a/src/main/java/com/ticketrush/application/reservation/model/ReservationQueueLockType.java
+++ b/src/main/java/com/ticketrush/application/reservation/model/ReservationQueueLockType.java
@@ -1,0 +1,6 @@
+package com.ticketrush.application.reservation.model;
+
+public enum ReservationQueueLockType {
+    OPTIMISTIC,
+    PESSIMISTIC
+}

--- a/src/main/java/com/ticketrush/application/reservation/service/AbuseAuditService.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/AbuseAuditService.java
@@ -1,7 +1,10 @@
 package com.ticketrush.application.reservation.service;
 
+import com.ticketrush.application.reservation.model.AbuseAuditActionType;
+import com.ticketrush.application.reservation.model.AbuseAuditReasonType;
+import com.ticketrush.application.reservation.model.AbuseAuditRecord;
+import com.ticketrush.application.reservation.model.AbuseAuditResultType;
 import com.ticketrush.domain.concert.entity.Seat;
-import com.ticketrush.domain.reservation.entity.AbuseAuditLog;
 import com.ticketrush.domain.user.User;
 
 import java.time.LocalDateTime;
@@ -12,10 +15,10 @@ public interface AbuseAuditService {
 
     void recordAllowedHold(String requestFingerprint, String deviceFingerprint, User user, Seat seat, Long reservationId, LocalDateTime now);
 
-    List<AbuseAuditLog> getAuditLogs(
-            AbuseAuditLog.AuditAction action,
-            AbuseAuditLog.AuditResult result,
-            AbuseAuditLog.AuditReason reason,
+    List<AbuseAuditRecord> getAuditLogs(
+            AbuseAuditActionType action,
+            AbuseAuditResultType result,
+            AbuseAuditReasonType reason,
             Long userId,
             Long concertId,
             LocalDateTime fromAt,

--- a/src/main/java/com/ticketrush/application/reservation/service/AbuseAuditServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/AbuseAuditServiceImpl.java
@@ -1,5 +1,9 @@
 package com.ticketrush.application.reservation.service;
 
+import com.ticketrush.application.reservation.model.AbuseAuditActionType;
+import com.ticketrush.application.reservation.model.AbuseAuditReasonType;
+import com.ticketrush.application.reservation.model.AbuseAuditRecord;
+import com.ticketrush.application.reservation.model.AbuseAuditResultType;
 import com.ticketrush.domain.concert.entity.Seat;
 import com.ticketrush.domain.reservation.entity.AbuseAuditLog;
 import com.ticketrush.domain.reservation.repository.AbuseAuditLogRepository;
@@ -47,10 +51,10 @@ public class AbuseAuditServiceImpl implements AbuseAuditService {
     }
 
     @Transactional(readOnly = true)
-    public List<AbuseAuditLog> getAuditLogs(
-            AbuseAuditLog.AuditAction action,
-            AbuseAuditLog.AuditResult result,
-            AbuseAuditLog.AuditReason reason,
+    public List<AbuseAuditRecord> getAuditLogs(
+            AbuseAuditActionType action,
+            AbuseAuditResultType result,
+            AbuseAuditReasonType reason,
             Long userId,
             Long concertId,
             LocalDateTime fromAt,
@@ -63,15 +67,18 @@ public class AbuseAuditServiceImpl implements AbuseAuditService {
         LocalDateTime resolvedFromAt = fromAt == null ? LocalDateTime.of(1970, 1, 1, 0, 0, 0) : fromAt;
         LocalDateTime resolvedToAt = toAt == null ? LocalDateTime.of(9999, 12, 31, 23, 59, 59) : toAt;
         return abuseAuditLogRepository.search(
-                action,
-                result,
-                reason,
-                userId,
-                concertId,
-                resolvedFromAt,
-                resolvedToAt,
-                PageRequest.of(0, resolvedLimit)
-        );
+                        toDomainAction(action),
+                        toDomainResult(result),
+                        toDomainReason(reason),
+                        userId,
+                        concertId,
+                        resolvedFromAt,
+                        resolvedToAt,
+                        PageRequest.of(0, resolvedLimit)
+                )
+                .stream()
+                .map(this::toRecord)
+                .toList();
     }
 
     private void ensureRateLimit(String requestFingerprint, String deviceFingerprint, User user, Seat seat, LocalDateTime now) {
@@ -170,5 +177,43 @@ public class AbuseAuditServiceImpl implements AbuseAuditService {
                 AbuseAuditLog.blockedHold(user, seat, requestFingerprint, deviceFingerprint, reason, message, LocalDateTime.now())
         );
         throw new IllegalStateException(message);
+    }
+
+    private AbuseAuditLog.AuditAction toDomainAction(AbuseAuditActionType action) {
+        if (action == null) {
+            return null;
+        }
+        return AbuseAuditLog.AuditAction.valueOf(action.name());
+    }
+
+    private AbuseAuditLog.AuditResult toDomainResult(AbuseAuditResultType result) {
+        if (result == null) {
+            return null;
+        }
+        return AbuseAuditLog.AuditResult.valueOf(result.name());
+    }
+
+    private AbuseAuditLog.AuditReason toDomainReason(AbuseAuditReasonType reason) {
+        if (reason == null) {
+            return null;
+        }
+        return AbuseAuditLog.AuditReason.valueOf(reason.name());
+    }
+
+    private AbuseAuditRecord toRecord(AbuseAuditLog log) {
+        return new AbuseAuditRecord(
+                log.getId(),
+                AbuseAuditActionType.valueOf(log.getAction().name()),
+                AbuseAuditResultType.valueOf(log.getResult().name()),
+                AbuseAuditReasonType.valueOf(log.getReason().name()),
+                log.getUserId(),
+                log.getConcertId(),
+                log.getSeatId(),
+                log.getReservationId(),
+                log.getRequestFingerprint(),
+                log.getDeviceFingerprint(),
+                log.getDetailMessage(),
+                log.getOccurredAt()
+        );
     }
 }

--- a/src/main/java/com/ticketrush/application/reservation/service/AdminRefundAuditService.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/AdminRefundAuditService.java
@@ -1,5 +1,7 @@
 package com.ticketrush.application.reservation.service;
 
+import com.ticketrush.application.reservation.model.AdminRefundAuditRecord;
+import com.ticketrush.application.reservation.model.AdminRefundAuditResultType;
 import com.ticketrush.domain.reservation.entity.AdminRefundAuditLog;
 import com.ticketrush.domain.reservation.repository.AdminRefundAuditLogRepository;
 import com.ticketrush.domain.user.UserRole;
@@ -58,22 +60,25 @@ public class AdminRefundAuditService {
     }
 
     @Transactional(readOnly = true)
-    public List<AdminRefundAuditLog> getAuditLogs(
+    public List<AdminRefundAuditRecord> getAuditLogs(
             Long reservationId,
             Long actorUserId,
-            AdminRefundAuditLog.AuditResult result,
+            AdminRefundAuditResultType result,
             LocalDateTime fromAt,
             LocalDateTime toAt,
             Integer limit
     ) {
         return adminRefundAuditLogRepository.search(
-                reservationId,
-                actorUserId,
-                result,
-                fromAt,
-                toAt,
-                PageRequest.of(0, normalizeLimit(limit))
-        );
+                        reservationId,
+                        actorUserId,
+                        toDomainResult(result),
+                        fromAt,
+                        toAt,
+                        PageRequest.of(0, normalizeLimit(limit))
+                )
+                .stream()
+                .map(this::toRecord)
+                .toList();
     }
 
     private int normalizeLimit(Integer limit) {
@@ -81,5 +86,25 @@ public class AdminRefundAuditService {
             return 50;
         }
         return Math.min(limit, 200);
+    }
+
+    private AdminRefundAuditLog.AuditResult toDomainResult(AdminRefundAuditResultType result) {
+        if (result == null) {
+            return null;
+        }
+        return AdminRefundAuditLog.AuditResult.valueOf(result.name());
+    }
+
+    private AdminRefundAuditRecord toRecord(AdminRefundAuditLog log) {
+        return new AdminRefundAuditRecord(
+                log.getId(),
+                log.getReservationId(),
+                log.getTargetUserId(),
+                log.getActorUserId(),
+                log.getActorRole(),
+                AdminRefundAuditResultType.valueOf(log.getResult().name()),
+                log.getDetailMessage(),
+                log.getOccurredAt()
+        );
     }
 }

--- a/src/main/java/com/ticketrush/global/messaging/KafkaReservationProducer.java
+++ b/src/main/java/com/ticketrush/global/messaging/KafkaReservationProducer.java
@@ -1,5 +1,6 @@
 package com.ticketrush.global.messaging;
 
+import com.ticketrush.application.reservation.model.ReservationQueueLockType;
 import com.ticketrush.domain.reservation.event.ReservationEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,11 @@ public class KafkaReservationProducer {
 
     @Value("${app.kafka.topic.reservation}")
     private String topic;
+
+    public void send(Long userId, Long seatId, ReservationQueueLockType lockType) {
+        ReservationEvent.LockType domainLockType = ReservationEvent.LockType.valueOf(lockType.name());
+        send(ReservationEvent.of(userId, seatId, domainLockType));
+    }
 
     public void send(ReservationEvent event) {
         log.info("Sending reservation event to Kafka - Topic: {}, UserId: {}, SeatId: {}", 

--- a/src/test/java/com/ticketrush/application/reservation/service/ReservationLifecycleServiceIntegrationTest.java
+++ b/src/test/java/com/ticketrush/application/reservation/service/ReservationLifecycleServiceIntegrationTest.java
@@ -3,6 +3,10 @@ package com.ticketrush.application.reservation.service;
 import com.ticketrush.application.reservation.service.ReservationLifecycleService;
 import com.ticketrush.application.reservation.service.ReservationLifecycleServiceImpl;
 import com.ticketrush.application.reservation.service.SalesPolicyServiceImpl;
+import com.ticketrush.application.reservation.model.AbuseAuditActionType;
+import com.ticketrush.application.reservation.model.AbuseAuditReasonType;
+import com.ticketrush.application.reservation.model.AbuseAuditRecord;
+import com.ticketrush.application.reservation.model.AbuseAuditResultType;
 import com.ticketrush.application.reservation.model.ReservationCreateCommand;
 import com.ticketrush.application.reservation.model.ReservationLifecycleResult;
 import com.ticketrush.domain.entertainment.Entertainment;
@@ -513,10 +517,10 @@ class ReservationLifecycleServiceIntegrationTest {
                 new ReservationCreateCommand(user.getId(), secondSeat.getId(), "audit-dup-1", "audit-device")
         )).isInstanceOf(IllegalStateException.class);
 
-        List<AbuseAuditLog> blockedLogs = abuseAuditService.getAuditLogs(
-                AbuseAuditLog.AuditAction.HOLD_CREATE,
-                AbuseAuditLog.AuditResult.BLOCKED,
-                AbuseAuditLog.AuditReason.DUPLICATE_REQUEST_FINGERPRINT,
+        List<AbuseAuditRecord> blockedLogs = abuseAuditService.getAuditLogs(
+                AbuseAuditActionType.HOLD_CREATE,
+                AbuseAuditResultType.BLOCKED,
+                AbuseAuditReasonType.DUPLICATE_REQUEST_FINGERPRINT,
                 user.getId(),
                 null,
                 null,
@@ -524,7 +528,7 @@ class ReservationLifecycleServiceIntegrationTest {
                 10
         );
         assertThat(blockedLogs).isNotEmpty();
-        assertThat(blockedLogs.get(0).getReason()).isEqualTo(AbuseAuditLog.AuditReason.DUPLICATE_REQUEST_FINGERPRINT);
+        assertThat(blockedLogs.get(0).reason()).isEqualTo(AbuseAuditReasonType.DUPLICATE_REQUEST_FINGERPRINT);
     }
 
     private Seat saveSeat(String seatNo) {

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -33,5 +33,5 @@ class LayerDependencyArchTest {
     static final ArchRule reservation_controller_should_not_depend_on_domain_reservation_services =
             noClasses()
                     .that().haveFullyQualifiedName("com.ticketrush.api.controller.ReservationController")
-                    .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.reservation.service..");
+                    .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.reservation..");
 }


### PR DESCRIPTION
## Summary
- remove direct `domain.reservation` type dependencies from `ReservationController`
  - queue lock type switched to application enum (`ReservationQueueLockType`)
  - abuse/admin audit query/result types switched to application models
- add application reservation audit/queue models
  - `AbuseAuditActionType`, `AbuseAuditResultType`, `AbuseAuditReasonType`
  - `AbuseAuditRecord`
  - `AdminRefundAuditResultType`, `AdminRefundAuditRecord`
  - `ReservationQueueLockType`
- update reservation audit services and API DTO mappers to application-model signatures
- strengthen ArchUnit reservation-controller rule scope to `domain.reservation..`

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest' --tests 'com.ticketrush.application.reservation.service.ReservationLifecycleServiceIntegrationTest' --tests 'com.ticketrush.global.scheduler.ReservationLifecycleSchedulerTest'`

Refs #33
