### PR TITLE
[DDD] Phase4-F Catalog Service Application Relocation

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/ArtistController.java
+++ b/src/main/java/com/ticketrush/api/controller/ArtistController.java
@@ -3,7 +3,7 @@ package com.ticketrush.api.controller;
 import com.ticketrush.api.dto.ArtistResponse;
 import com.ticketrush.api.dto.ArtistSearchPageResponse;
 import com.ticketrush.api.dto.ArtistUpsertRequest;
-import com.ticketrush.domain.artist.service.ArtistService;
+import com.ticketrush.application.catalog.service.ArtistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/ticketrush/api/controller/EntertainmentCatalogController.java
+++ b/src/main/java/com/ticketrush/api/controller/EntertainmentCatalogController.java
@@ -3,7 +3,7 @@ package com.ticketrush.api.controller;
 import com.ticketrush.api.dto.EntertainmentResponse;
 import com.ticketrush.api.dto.EntertainmentSearchPageResponse;
 import com.ticketrush.api.dto.EntertainmentUpsertRequest;
-import com.ticketrush.domain.entertainment.service.EntertainmentService;
+import com.ticketrush.application.catalog.service.EntertainmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/ticketrush/api/controller/EntertainmentController.java
+++ b/src/main/java/com/ticketrush/api/controller/EntertainmentController.java
@@ -3,7 +3,7 @@ package com.ticketrush.api.controller;
 import com.ticketrush.api.dto.EntertainmentResponse;
 import com.ticketrush.api.dto.EntertainmentSearchPageResponse;
 import com.ticketrush.api.dto.EntertainmentUpsertRequest;
-import com.ticketrush.domain.entertainment.service.EntertainmentService;
+import com.ticketrush.application.catalog.service.EntertainmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/ticketrush/api/controller/PromoterController.java
+++ b/src/main/java/com/ticketrush/api/controller/PromoterController.java
@@ -3,7 +3,7 @@ package com.ticketrush.api.controller;
 import com.ticketrush.api.dto.PromoterResponse;
 import com.ticketrush.api.dto.PromoterSearchPageResponse;
 import com.ticketrush.api.dto.PromoterUpsertRequest;
-import com.ticketrush.domain.promoter.service.PromoterService;
+import com.ticketrush.application.catalog.service.PromoterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/ticketrush/api/controller/VenueController.java
+++ b/src/main/java/com/ticketrush/api/controller/VenueController.java
@@ -3,7 +3,7 @@ package com.ticketrush.api.controller;
 import com.ticketrush.api.dto.VenueResponse;
 import com.ticketrush.api.dto.VenueSearchPageResponse;
 import com.ticketrush.api.dto.VenueUpsertRequest;
-import com.ticketrush.domain.venue.service.VenueService;
+import com.ticketrush.application.catalog.service.VenueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/ticketrush/application/catalog/service/ArtistService.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/ArtistService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.artist.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.artist.Artist;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/ticketrush/application/catalog/service/ArtistServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/ArtistServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.artist.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.entertainment.Entertainment;
 import com.ticketrush.domain.entertainment.EntertainmentRepository;

--- a/src/main/java/com/ticketrush/application/catalog/service/EntertainmentService.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/EntertainmentService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.entertainment.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.entertainment.Entertainment;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/ticketrush/application/catalog/service/EntertainmentServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/EntertainmentServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.entertainment.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.entertainment.Entertainment;
 import com.ticketrush.domain.entertainment.EntertainmentRepository;

--- a/src/main/java/com/ticketrush/application/catalog/service/PromoterService.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/PromoterService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.promoter.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.promoter.Promoter;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/ticketrush/application/catalog/service/PromoterServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/PromoterServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.promoter.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.concert.repository.ConcertRepository;
 import com.ticketrush.domain.promoter.Promoter;

--- a/src/main/java/com/ticketrush/application/catalog/service/VenueService.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/VenueService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.venue.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.venue.Venue;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/ticketrush/application/catalog/service/VenueServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/catalog/service/VenueServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.venue.service;
+package com.ticketrush.application.catalog.service;
 
 import com.ticketrush.domain.concert.repository.ConcertOptionRepository;
 import com.ticketrush.domain.venue.Venue;

--- a/src/test/java/com/ticketrush/application/catalog/service/EntertainmentArtistCrudDataJpaTest.java
+++ b/src/test/java/com/ticketrush/application/catalog/service/EntertainmentArtistCrudDataJpaTest.java
@@ -1,9 +1,9 @@
-package com.ticketrush.domain.catalog.service;
+package com.ticketrush.application.catalog.service;
 
-import com.ticketrush.domain.entertainment.service.EntertainmentService;
-import com.ticketrush.domain.entertainment.service.EntertainmentServiceImpl;
-import com.ticketrush.domain.artist.service.ArtistService;
-import com.ticketrush.domain.artist.service.ArtistServiceImpl;
+import com.ticketrush.application.catalog.service.EntertainmentService;
+import com.ticketrush.application.catalog.service.EntertainmentServiceImpl;
+import com.ticketrush.application.catalog.service.ArtistService;
+import com.ticketrush.application.catalog.service.ArtistServiceImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -42,6 +42,21 @@ class LayerDependencyArchTest {
                     .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.reservation..");
 
     @ArchTest
+    static final ArchRule catalog_controllers_should_not_depend_on_domain_catalog_services =
+            noClasses()
+                    .that().haveFullyQualifiedName("com.ticketrush.api.controller.EntertainmentController")
+                    .or().haveFullyQualifiedName("com.ticketrush.api.controller.EntertainmentCatalogController")
+                    .or().haveFullyQualifiedName("com.ticketrush.api.controller.ArtistController")
+                    .or().haveFullyQualifiedName("com.ticketrush.api.controller.PromoterController")
+                    .or().haveFullyQualifiedName("com.ticketrush.api.controller.VenueController")
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            "com.ticketrush.domain.entertainment.service..",
+                            "com.ticketrush.domain.artist.service..",
+                            "com.ticketrush.domain.promoter.service..",
+                            "com.ticketrush.domain.venue.service.."
+                    );
+
+    @ArchTest
     static final ArchRule global_messaging_should_not_depend_on_domain_reservation_events =
             noClasses()
                     .that().resideInAPackage("com.ticketrush.global.messaging..")


### PR DESCRIPTION
## Summary
- relocate catalog CRUD services (`Entertainment/Artist/Promoter/Venue`) from `domain.*.service` to `application.catalog.service`
- update catalog controllers and catalog CRUD DataJpa test to application service imports/package
- add ArchUnit guardrail: catalog controllers must not depend on `domain.*.service`

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest' --tests 'com.ticketrush.application.catalog.service.EntertainmentArtistCrudDataJpaTest'`

## Tracking
- refs #33
