### PR TITLE
[DDD] Phase4-H Concert Service Application Relocation

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/AdminConcertController.java
+++ b/src/main/java/com/ticketrush/api/controller/AdminConcertController.java
@@ -1,6 +1,7 @@
 package com.ticketrush.api.controller;
 
 import com.ticketrush.application.reservation.model.SalesPolicyUpsertCommand;
+import com.ticketrush.application.concert.service.ConcertService;
 import com.ticketrush.api.dto.ConcertOptionResponse;
 import com.ticketrush.api.dto.ConcertResponse;
 import com.ticketrush.api.dto.admin.AdminConcertOptionCreateRequest;
@@ -8,7 +9,6 @@ import com.ticketrush.api.dto.admin.AdminConcertOptionUpdateRequest;
 import com.ticketrush.api.dto.admin.AdminConcertUpsertRequest;
 import com.ticketrush.api.dto.reservation.SalesPolicyResponse;
 import com.ticketrush.api.dto.reservation.SalesPolicyUpsertRequest;
-import com.ticketrush.domain.concert.service.ConcertService;
 import com.ticketrush.application.reservation.service.SalesPolicyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/ticketrush/api/controller/ConcertController.java
+++ b/src/main/java/com/ticketrush/api/controller/ConcertController.java
@@ -1,6 +1,7 @@
 package com.ticketrush.api.controller;
 
 import com.ticketrush.application.reservation.model.SalesPolicyUpsertCommand;
+import com.ticketrush.application.concert.service.ConcertService;
 import com.ticketrush.api.dto.ConcertOptionResponse;
 import com.ticketrush.api.dto.ConcertResponse;
 import com.ticketrush.api.dto.ConcertSearchPageResponse;
@@ -8,7 +9,6 @@ import com.ticketrush.api.dto.ConcertSetupRequest;
 import com.ticketrush.api.dto.SeatResponse;
 import com.ticketrush.api.dto.reservation.SalesPolicyResponse;
 import com.ticketrush.api.dto.reservation.SalesPolicyUpsertRequest;
-import com.ticketrush.domain.concert.service.ConcertService;
 import com.ticketrush.application.reservation.service.SalesPolicyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/ticketrush/application/concert/service/ConcertService.java
+++ b/src/main/java/com/ticketrush/application/concert/service/ConcertService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.concert.service;
+package com.ticketrush.application.concert.service;
 
 import com.ticketrush.domain.concert.entity.Concert;
 import com.ticketrush.domain.concert.entity.ConcertOption;

--- a/src/main/java/com/ticketrush/application/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/concert/service/ConcertServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.concert.service;
+package com.ticketrush.application.concert.service;
 
 import com.ticketrush.domain.entertainment.Entertainment;
 import com.ticketrush.domain.entertainment.EntertainmentRepository;

--- a/src/test/java/com/ticketrush/application/concert/service/ConcertExplorerIntegrationTest.java
+++ b/src/test/java/com/ticketrush/application/concert/service/ConcertExplorerIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.concert.service;
+package com.ticketrush.application.concert.service;
 
 import com.ticketrush.application.reservation.model.ReservationCreateCommand;
 import com.ticketrush.domain.concert.entity.Seat;

--- a/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_1_낙관적_락.java
+++ b/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_1_낙관적_락.java
@@ -5,7 +5,7 @@ import com.ticketrush.domain.concert.entity.Concert;
 import com.ticketrush.domain.concert.entity.ConcertOption;
 import com.ticketrush.domain.concert.entity.Seat;
 import com.ticketrush.domain.concert.repository.SeatRepository;
-import com.ticketrush.domain.concert.service.ConcertService;
+import com.ticketrush.application.concert.service.ConcertService;
 import com.ticketrush.domain.reservation.repository.ReservationRepository;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;

--- a/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_2_비관적_락.java
+++ b/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_2_비관적_락.java
@@ -5,7 +5,7 @@ import com.ticketrush.domain.concert.entity.Concert;
 import com.ticketrush.domain.concert.entity.ConcertOption;
 import com.ticketrush.domain.concert.entity.Seat;
 import com.ticketrush.domain.concert.repository.SeatRepository;
-import com.ticketrush.domain.concert.service.ConcertService;
+import com.ticketrush.application.concert.service.ConcertService;
 import com.ticketrush.domain.reservation.repository.ReservationRepository;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;

--- a/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_3_분산_락.java
+++ b/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_3_분산_락.java
@@ -4,7 +4,7 @@ import com.ticketrush.domain.concert.entity.Concert;
 import com.ticketrush.domain.concert.entity.ConcertOption;
 import com.ticketrush.domain.concert.entity.Seat;
 import com.ticketrush.domain.concert.repository.SeatRepository;
-import com.ticketrush.domain.concert.service.ConcertService;
+import com.ticketrush.application.concert.service.ConcertService;
 import com.ticketrush.domain.reservation.repository.ReservationRepository;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;

--- a/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_4_비동기_대기열.java
+++ b/src/test/java/com/ticketrush/application/reservation/service/동시성_테스트_4_비동기_대기열.java
@@ -5,7 +5,7 @@ import com.ticketrush.domain.concert.entity.Concert;
 import com.ticketrush.domain.concert.entity.ConcertOption;
 import com.ticketrush.domain.concert.entity.Seat;
 import com.ticketrush.domain.concert.repository.SeatRepository;
-import com.ticketrush.domain.concert.service.ConcertService;
+import com.ticketrush.application.concert.service.ConcertService;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;
 import com.ticketrush.api.dto.ReservationRequest;

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -68,6 +68,13 @@ class LayerDependencyArchTest {
                     );
 
     @ArchTest
+    static final ArchRule concert_controllers_should_not_depend_on_domain_concert_services =
+            noClasses()
+                    .that().haveFullyQualifiedName("com.ticketrush.api.controller.ConcertController")
+                    .or().haveFullyQualifiedName("com.ticketrush.api.controller.AdminConcertController")
+                    .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.concert.service..");
+
+    @ArchTest
     static final ArchRule global_messaging_should_not_depend_on_domain_reservation_events =
             noClasses()
                     .that().resideInAPackage("com.ticketrush.global.messaging..")


### PR DESCRIPTION
## Summary
- relocate `ConcertService*` from `domain.concert.service` to `application.concert.service`
- update `ConcertController` and `AdminConcertController` to application service imports
- update concert-related tests (concurrency tests, ConcertExplorerIntegrationTest package/import path)
- add ArchUnit guardrail for concert controller direct dependency on `domain.concert.service..`

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest' --tests 'com.ticketrush.application.reservation.service.ReservationLifecycleServiceIntegrationTest'`

## Tracking
- refs #33
