### PR TITLE
refactor: DDD Phase4-I payment service/gateway boundary

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/WalletController.java
+++ b/src/main/java/com/ticketrush/api/controller/WalletController.java
@@ -3,7 +3,7 @@ package com.ticketrush.api.controller;
 import com.ticketrush.api.dto.payment.PaymentTransactionResponse;
 import com.ticketrush.api.dto.payment.WalletBalanceResponse;
 import com.ticketrush.api.dto.payment.WalletChargeRequest;
-import com.ticketrush.domain.payment.service.PaymentService;
+import com.ticketrush.application.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/ticketrush/application/payment/service/PaymentService.java
+++ b/src/main/java/com/ticketrush/application/payment/service/PaymentService.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.payment.service;
+package com.ticketrush.application.payment.service;
 
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 

--- a/src/main/java/com/ticketrush/application/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/payment/service/PaymentServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.payment.service;
+package com.ticketrush.application.payment.service;
 
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;

--- a/src/main/java/com/ticketrush/infrastructure/payment/gateway/MockPaymentGateway.java
+++ b/src/main/java/com/ticketrush/infrastructure/payment/gateway/MockPaymentGateway.java
@@ -1,5 +1,6 @@
-package com.ticketrush.domain.payment.gateway;
+package com.ticketrush.infrastructure.payment.gateway;
 
+import com.ticketrush.domain.payment.gateway.PaymentGateway;
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
 import com.ticketrush.domain.payment.entity.PaymentTransactionType;

--- a/src/main/java/com/ticketrush/infrastructure/payment/gateway/PgReadyPaymentGateway.java
+++ b/src/main/java/com/ticketrush/infrastructure/payment/gateway/PgReadyPaymentGateway.java
@@ -1,5 +1,6 @@
-package com.ticketrush.domain.payment.gateway;
+package com.ticketrush.infrastructure.payment.gateway;
 
+import com.ticketrush.domain.payment.gateway.PaymentGateway;
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
 import com.ticketrush.domain.payment.entity.PaymentTransactionType;

--- a/src/main/java/com/ticketrush/infrastructure/payment/gateway/WalletPaymentGateway.java
+++ b/src/main/java/com/ticketrush/infrastructure/payment/gateway/WalletPaymentGateway.java
@@ -1,7 +1,8 @@
-package com.ticketrush.domain.payment.gateway;
+package com.ticketrush.infrastructure.payment.gateway;
 
+import com.ticketrush.application.payment.service.PaymentService;
+import com.ticketrush.domain.payment.gateway.PaymentGateway;
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
-import com.ticketrush.domain.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;

--- a/src/test/java/com/ticketrush/application/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/ticketrush/application/payment/service/PaymentServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.domain.payment.service;
+package com.ticketrush.application.payment.service;
 
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.entity.PaymentTransactionType;

--- a/src/test/java/com/ticketrush/application/reservation/service/ReservationLifecycleServiceIntegrationTest.java
+++ b/src/test/java/com/ticketrush/application/reservation/service/ReservationLifecycleServiceIntegrationTest.java
@@ -23,9 +23,9 @@ import com.ticketrush.infrastructure.reservation.adapter.outbound.ReservationWai
 import com.ticketrush.domain.concert.repository.ConcertOptionRepository;
 import com.ticketrush.domain.concert.repository.ConcertRepository;
 import com.ticketrush.domain.concert.repository.SeatRepository;
-import com.ticketrush.domain.payment.service.PaymentService;
-import com.ticketrush.domain.payment.service.PaymentServiceImpl;
-import com.ticketrush.domain.payment.gateway.WalletPaymentGateway;
+import com.ticketrush.application.payment.service.PaymentService;
+import com.ticketrush.application.payment.service.PaymentServiceImpl;
+import com.ticketrush.infrastructure.payment.gateway.WalletPaymentGateway;
 import com.ticketrush.domain.reservation.entity.AdminRefundAuditLog;
 import com.ticketrush.domain.reservation.entity.AbuseAuditLog;
 import com.ticketrush.domain.reservation.entity.Reservation;

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -75,6 +75,12 @@ class LayerDependencyArchTest {
                     .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.concert.service..");
 
     @ArchTest
+    static final ArchRule wallet_controller_should_not_depend_on_domain_payment_services =
+            noClasses()
+                    .that().haveFullyQualifiedName("com.ticketrush.api.controller.WalletController")
+                    .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.payment.service..");
+
+    @ArchTest
     static final ArchRule global_messaging_should_not_depend_on_domain_reservation_events =
             noClasses()
                     .that().resideInAPackage("com.ticketrush.global.messaging..")

--- a/src/test/java/com/ticketrush/infrastructure/payment/gateway/MockPaymentGatewayIntegrationTest.java
+++ b/src/test/java/com/ticketrush/infrastructure/payment/gateway/MockPaymentGatewayIntegrationTest.java
@@ -1,7 +1,8 @@
-package com.ticketrush.domain.payment.gateway;
+package com.ticketrush.infrastructure.payment.gateway;
 
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import com.ticketrush.domain.payment.gateway.PaymentGateway;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/ticketrush/infrastructure/payment/gateway/PgReadyPaymentGatewayIntegrationTest.java
+++ b/src/test/java/com/ticketrush/infrastructure/payment/gateway/PgReadyPaymentGatewayIntegrationTest.java
@@ -1,8 +1,9 @@
-package com.ticketrush.domain.payment.gateway;
+package com.ticketrush.infrastructure.payment.gateway;
 
 import com.ticketrush.domain.payment.entity.PaymentTransaction;
 import com.ticketrush.domain.payment.entity.PaymentTransactionStatus;
 import com.ticketrush.domain.payment.entity.PaymentTransactionType;
+import com.ticketrush.domain.payment.gateway.PaymentGateway;
 import com.ticketrush.domain.user.User;
 import com.ticketrush.domain.user.UserRepository;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- move `PaymentService*` from `domain.payment.service` to `application.payment.service`
- move payment gateway implementations (`Wallet/Mock/PgReady`) to `infrastructure.payment.gateway`
- update `WalletController`, reservation lifecycle integration wiring, and payment integration test packages
- add ArchUnit rule to block `WalletController -> domain.payment.service..` dependency

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest' --tests 'com.ticketrush.application.payment.service.PaymentServiceIntegrationTest' --tests 'com.ticketrush.infrastructure.payment.gateway.MockPaymentGatewayIntegrationTest' --tests 'com.ticketrush.infrastructure.payment.gateway.PgReadyPaymentGatewayIntegrationTest' --tests 'com.ticketrush.application.reservation.service.ReservationLifecycleServiceIntegrationTest'`

## Tracking
- refs #33
