### PR TITLE
refactor: DDD Phase5-A application redis port/adapter split

### DIFF
--- a/src/main/java/com/ticketrush/application/reservation/port/outbound/ReservationQueueStatusStore.java
+++ b/src/main/java/com/ticketrush/application/reservation/port/outbound/ReservationQueueStatusStore.java
@@ -1,0 +1,10 @@
+package com.ticketrush.application.reservation.port.outbound;
+
+import java.util.concurrent.TimeUnit;
+
+public interface ReservationQueueStatusStore {
+
+    void setStatus(Long userId, Long seatId, String status, long ttl, TimeUnit unit);
+
+    String getStatus(Long userId, Long seatId);
+}

--- a/src/main/java/com/ticketrush/application/reservation/port/outbound/SeatSoftLockStore.java
+++ b/src/main/java/com/ticketrush/application/reservation/port/outbound/SeatSoftLockStore.java
@@ -1,0 +1,14 @@
+package com.ticketrush.application.reservation.port.outbound;
+
+import java.util.concurrent.TimeUnit;
+
+public interface SeatSoftLockStore {
+
+    boolean setIfAbsent(String key, String value, long ttl, TimeUnit unit);
+
+    void set(String key, String value, long ttl, TimeUnit unit);
+
+    String get(String key);
+
+    void delete(String key);
+}

--- a/src/main/java/com/ticketrush/application/reservation/service/ReservationQueueServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/ReservationQueueServiceImpl.java
@@ -1,7 +1,7 @@
 package com.ticketrush.application.reservation.service;
 
+import com.ticketrush.application.reservation.port.outbound.ReservationQueueStatusStore;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.TimeUnit;
@@ -10,27 +10,21 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class ReservationQueueServiceImpl implements ReservationQueueService {
 
-    private final StringRedisTemplate redisTemplate;
+    private final ReservationQueueStatusStore reservationQueueStatusStore;
 
-    private static final String STATUS_KEY_PREFIX = "reservation:status:";
     private static final long STATUS_TTL_MINUTES = 30;
 
     /**
      * 예약 상태 저장 (userId와 seatId 조합을 키로 사용)
      */
     public void setStatus(Long userId, Long seatId, String status) {
-        String key = generateKey(userId, seatId);
-        redisTemplate.opsForValue().set(key, status, STATUS_TTL_MINUTES, TimeUnit.MINUTES);
+        reservationQueueStatusStore.setStatus(userId, seatId, status, STATUS_TTL_MINUTES, TimeUnit.MINUTES);
     }
 
     /**
      * 예약 상태 조회
      */
     public String getStatus(Long userId, Long seatId) {
-        return redisTemplate.opsForValue().get(generateKey(userId, seatId));
-    }
-
-    private String generateKey(Long userId, Long seatId) {
-        return STATUS_KEY_PREFIX + userId + ":" + seatId;
+        return reservationQueueStatusStore.getStatus(userId, seatId);
     }
 }

--- a/src/main/java/com/ticketrush/application/reservation/service/SeatSoftLockServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/reservation/service/SeatSoftLockServiceImpl.java
@@ -1,11 +1,11 @@
 package com.ticketrush.application.reservation.service;
 
+import com.ticketrush.application.reservation.port.outbound.SeatSoftLockStore;
 import com.ticketrush.domain.concert.entity.Seat;
 import com.ticketrush.domain.reservation.port.outbound.ReservationSeatPort;
 import com.ticketrush.global.config.ReservationProperties;
 import com.ticketrush.global.push.PushNotifier;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -22,7 +22,7 @@ public class SeatSoftLockServiceImpl implements SeatSoftLockService {
     private static final String STATUS_RELEASED = "RELEASED";
     private static final String STATUS_HOLD = "HOLD";
 
-    private final StringRedisTemplate redisTemplate;
+    private final SeatSoftLockStore seatSoftLockStore;
     private final ReservationSeatPort reservationSeatPort;
     private final ReservationProperties reservationProperties;
     private final PushNotifier pushNotifier;
@@ -36,13 +36,13 @@ public class SeatSoftLockServiceImpl implements SeatSoftLockService {
         String key = context.key();
         String encodedValue = encode(new LockValue(userId, resolvedRequestId, expiresAt));
 
-        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, encodedValue, ttlSeconds, TimeUnit.SECONDS);
-        if (!Boolean.TRUE.equals(acquired)) {
-            LockValue current = decode(redisTemplate.opsForValue().get(key));
+        boolean acquired = seatSoftLockStore.setIfAbsent(key, encodedValue, ttlSeconds, TimeUnit.SECONDS);
+        if (!acquired) {
+            LockValue current = decode(seatSoftLockStore.get(key));
             if (current == null || !userId.equals(current.ownerUserId())) {
                 throw new IllegalStateException("Seat is already selecting by another user. seatId=" + seatId);
             }
-            redisTemplate.opsForValue().set(key, encodedValue, ttlSeconds, TimeUnit.SECONDS);
+            seatSoftLockStore.set(key, encodedValue, ttlSeconds, TimeUnit.SECONDS);
         }
 
         pushNotifier.sendSeatMapStatus(context.optionId(), seatId, STATUS_SELECTING, userId, expiresAt);
@@ -61,7 +61,7 @@ public class SeatSoftLockServiceImpl implements SeatSoftLockService {
     public SeatSoftLockReleaseResult release(Long userId, Long seatId) {
         SeatContext context = seatContext(seatId);
         String key = context.key();
-        LockValue current = decode(redisTemplate.opsForValue().get(key));
+        LockValue current = decode(seatSoftLockStore.get(key));
 
         if (current == null) {
             return new SeatSoftLockReleaseResult(context.optionId(), seatId, STATUS_RELEASED, false);
@@ -70,7 +70,7 @@ public class SeatSoftLockServiceImpl implements SeatSoftLockService {
             throw new IllegalStateException("Seat soft lock owner mismatch. seatId=" + seatId);
         }
 
-        redisTemplate.delete(key);
+        seatSoftLockStore.delete(key);
         pushNotifier.sendSeatMapStatus(context.optionId(), seatId, STATUS_RELEASED, null, null);
         return new SeatSoftLockReleaseResult(context.optionId(), seatId, STATUS_RELEASED, true);
     }
@@ -78,7 +78,7 @@ public class SeatSoftLockServiceImpl implements SeatSoftLockService {
     @Override
     public void ensureHoldableByUser(Long userId, Long seatId) {
         SeatContext context = seatContext(seatId);
-        LockValue current = decode(redisTemplate.opsForValue().get(context.key()));
+        LockValue current = decode(seatSoftLockStore.get(context.key()));
         if (current != null && !userId.equals(current.ownerUserId())) {
             throw new IllegalStateException("Seat is selecting by another user. seatId=" + seatId);
         }
@@ -87,7 +87,7 @@ public class SeatSoftLockServiceImpl implements SeatSoftLockService {
     @Override
     public void promoteToHold(Long userId, Long seatId, LocalDateTime holdExpiresAt) {
         SeatContext context = seatContext(seatId);
-        redisTemplate.delete(context.key());
+        seatSoftLockStore.delete(context.key());
         pushNotifier.sendSeatMapStatus(
                 context.optionId(),
                 seatId,

--- a/src/main/java/com/ticketrush/application/waitingqueue/port/outbound/WaitingQueueStore.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/port/outbound/WaitingQueueStore.java
@@ -1,0 +1,19 @@
+package com.ticketrush.application.waitingqueue.port.outbound;
+
+import java.util.List;
+
+public interface WaitingQueueStore {
+
+    JoinAndRankResult joinAndRank(String queueKey, String activeKey, String userId, long score, long maxQueueSize);
+
+    boolean hasActiveUser(String activeKey);
+
+    Long rank(String queueKey, String userId);
+
+    List<String> activateUsers(String queueKey, String activeKeyPrefix, long ttlSeconds, long count);
+
+    Long ttlSeconds(String key);
+
+    record JoinAndRankResult(long resultCode, long rank) {
+    }
+}

--- a/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImpl.java
@@ -4,9 +4,8 @@ import com.ticketrush.application.waitingqueue.model.WaitingQueueJoinCommand;
 import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusQuery;
 import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusResult;
 import com.ticketrush.application.waitingqueue.model.WaitingQueueStatusType;
+import com.ticketrush.application.waitingqueue.port.outbound.WaitingQueueStore;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -17,72 +16,12 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class WaitingQueueServiceImpl implements WaitingQueueService {
 
-    private final StringRedisTemplate redisTemplate;
+    private final WaitingQueueStore waitingQueueStore;
     private final com.ticketrush.global.config.WaitingQueueProperties properties;
     private static final long JOIN_RESULT_ACTIVE = 1L;
     private static final long JOIN_RESULT_REJECTED = 2L;
     private static final long JOIN_RESULT_WAITING = 3L;
     private static final long JOIN_RESULT_UNKNOWN = 4L;
-    private static final DefaultRedisScript<List> JOIN_AND_RANK_SCRIPT;
-    private static final DefaultRedisScript<List> ACTIVATE_USERS_SCRIPT;
-
-    static {
-        JOIN_AND_RANK_SCRIPT = new DefaultRedisScript<>();
-        JOIN_AND_RANK_SCRIPT.setResultType(List.class);
-        JOIN_AND_RANK_SCRIPT.setScriptText("""
-                local queueKey = KEYS[1]
-                local activeKey = KEYS[2]
-                local userId = ARGV[1]
-                local score = tonumber(ARGV[2])
-                local maxQueueSize = tonumber(ARGV[3])
-
-                if redis.call('EXISTS', activeKey) == 1 then
-                    return {1, 0}
-                end
-
-                local existingRank = redis.call('ZRANK', queueKey, userId)
-                if existingRank then
-                    return {3, existingRank + 1}
-                end
-
-                local currentQueueSize = redis.call('ZCARD', queueKey)
-                if currentQueueSize >= maxQueueSize then
-                    return {2, -1}
-                end
-
-                redis.call('ZADD', queueKey, score, userId)
-                local addedRank = redis.call('ZRANK', queueKey, userId)
-                if addedRank then
-                    return {3, addedRank + 1}
-                end
-
-                return {4, -1}
-                """);
-
-        ACTIVATE_USERS_SCRIPT = new DefaultRedisScript<>();
-        ACTIVATE_USERS_SCRIPT.setResultType(List.class);
-        ACTIVATE_USERS_SCRIPT.setScriptText("""
-                local queueKey = KEYS[1]
-                local activeKeyPrefix = ARGV[1]
-                local ttlSeconds = tonumber(ARGV[2])
-                local count = tonumber(ARGV[3])
-
-                if count <= 0 then
-                    return {}
-                end
-
-                local popped = redis.call('ZPOPMIN', queueKey, count)
-                local activatedUsers = {}
-
-                for i = 1, #popped, 2 do
-                    local userId = popped[i]
-                    redis.call('SET', activeKeyPrefix .. userId, 'true', 'EX', ttlSeconds)
-                    table.insert(activatedUsers, userId)
-                end
-
-                return activatedUsers
-                """);
-    }
 
     @Override
     public WaitingQueueStatusResult join(WaitingQueueJoinCommand command) {
@@ -91,19 +30,19 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
         String activeKey = properties.getActiveKeyPrefix() + userIdStr;
 
         // Redis round trip을 줄이기 위해 join/throttling/rank 계산을 Lua 스크립트로 원자 처리한다.
-        List<?> scriptResult = redisTemplate.execute(
-                JOIN_AND_RANK_SCRIPT,
-                List.of(queueKey, activeKey),
+        WaitingQueueStore.JoinAndRankResult scriptResult = waitingQueueStore.joinAndRank(
+                queueKey,
+                activeKey,
                 userIdStr,
-                String.valueOf(System.currentTimeMillis()),
-                String.valueOf(properties.getMaxQueueSize())
+                System.currentTimeMillis(),
+                properties.getMaxQueueSize()
         );
-        if (scriptResult == null || scriptResult.size() < 2) {
+        if (scriptResult == null) {
             return getStatus(new WaitingQueueStatusQuery(command.getUserId(), command.getConcertId()));
         }
 
-        long resultCode = toLong(scriptResult.get(0), JOIN_RESULT_UNKNOWN);
-        long rank = toLong(scriptResult.get(1), -1L);
+        long resultCode = scriptResult.resultCode();
+        long rank = scriptResult.rank();
 
         if (resultCode == JOIN_RESULT_ACTIVE) {
             return buildResponse(command.getUserId(), command.getConcertId(), WaitingQueueStatusType.ACTIVE, 0L);
@@ -123,13 +62,13 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
         String userIdStr = String.valueOf(query.getUserId());
 
         // 1. 활성 상태 확인
-        if (Boolean.TRUE.equals(redisTemplate.hasKey(properties.getActiveKeyPrefix() + userIdStr))) {
+        if (waitingQueueStore.hasActiveUser(properties.getActiveKeyPrefix() + userIdStr)) {
             return buildResponse(query.getUserId(), query.getConcertId(), WaitingQueueStatusType.ACTIVE, 0L);
         }
 
         // 2. 대기 순번 조회
         String queueKey = properties.getQueueKeyPrefix() + query.getConcertId();
-        Long rank = redisTemplate.opsForZSet().rank(queueKey, userIdStr);
+        Long rank = waitingQueueStore.rank(queueKey, userIdStr);
 
         return buildResponse(
                 query.getUserId(),
@@ -147,20 +86,19 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
 
         String queueKey = properties.getQueueKeyPrefix() + concertId;
         long activeTtlSeconds = TimeUnit.MINUTES.toSeconds(properties.getActiveTtlMinutes());
-        List<?> scriptResult = redisTemplate.execute(
-                ACTIVATE_USERS_SCRIPT,
-                List.of(queueKey),
+        List<String> rawActivatedUsers = waitingQueueStore.activateUsers(
+                queueKey,
                 properties.getActiveKeyPrefix(),
-                String.valueOf(activeTtlSeconds),
-                String.valueOf(count)
+                activeTtlSeconds,
+                count
         );
 
-        if (scriptResult == null || scriptResult.isEmpty()) {
+        if (rawActivatedUsers == null || rawActivatedUsers.isEmpty()) {
             return List.of();
         }
 
-        List<Long> activatedUsers = new ArrayList<>(scriptResult.size());
-        for (Object rawUserId : scriptResult) {
+        List<Long> activatedUsers = new ArrayList<>(rawActivatedUsers.size());
+        for (String rawUserId : rawActivatedUsers) {
             Long userId = parseLong(rawUserId);
             if (userId != null) {
                 activatedUsers.add(userId);
@@ -172,7 +110,7 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
     @Override
     public Long getActiveTtlSeconds(Long userId) {
         String activeKey = properties.getActiveKeyPrefix() + userId;
-        Long ttl = redisTemplate.getExpire(activeKey, TimeUnit.SECONDS);
+        Long ttl = waitingQueueStore.ttlSeconds(activeKey);
         return (ttl != null && ttl > 0) ? ttl : 0L;
     }
 
@@ -185,17 +123,7 @@ public class WaitingQueueServiceImpl implements WaitingQueueService {
                 .build();
     }
 
-    private long toLong(Object value, long defaultValue) {
-        if (value instanceof Number number) {
-            return number.longValue();
-        }
-        return defaultValue;
-    }
-
-    private Long parseLong(Object rawValue) {
-        if (rawValue instanceof Number number) {
-            return number.longValue();
-        }
+    private Long parseLong(String rawValue) {
         if (rawValue == null) {
             return null;
         }

--- a/src/main/java/com/ticketrush/infrastructure/reservation/adapter/outbound/RedisReservationQueueStatusStoreAdapter.java
+++ b/src/main/java/com/ticketrush/infrastructure/reservation/adapter/outbound/RedisReservationQueueStatusStoreAdapter.java
@@ -1,0 +1,31 @@
+package com.ticketrush.infrastructure.reservation.adapter.outbound;
+
+import com.ticketrush.application.reservation.port.outbound.ReservationQueueStatusStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisReservationQueueStatusStoreAdapter implements ReservationQueueStatusStore {
+
+    private static final String STATUS_KEY_PREFIX = "reservation:status:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void setStatus(Long userId, Long seatId, String status, long ttl, TimeUnit unit) {
+        redisTemplate.opsForValue().set(key(userId, seatId), status, ttl, unit);
+    }
+
+    @Override
+    public String getStatus(Long userId, Long seatId) {
+        return redisTemplate.opsForValue().get(key(userId, seatId));
+    }
+
+    private String key(Long userId, Long seatId) {
+        return STATUS_KEY_PREFIX + userId + ":" + seatId;
+    }
+}

--- a/src/main/java/com/ticketrush/infrastructure/reservation/adapter/outbound/RedisSeatSoftLockStoreAdapter.java
+++ b/src/main/java/com/ticketrush/infrastructure/reservation/adapter/outbound/RedisSeatSoftLockStoreAdapter.java
@@ -1,0 +1,35 @@
+package com.ticketrush.infrastructure.reservation.adapter.outbound;
+
+import com.ticketrush.application.reservation.port.outbound.SeatSoftLockStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisSeatSoftLockStoreAdapter implements SeatSoftLockStore {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public boolean setIfAbsent(String key, String value, long ttl, TimeUnit unit) {
+        return Boolean.TRUE.equals(redisTemplate.opsForValue().setIfAbsent(key, value, ttl, unit));
+    }
+
+    @Override
+    public void set(String key, String value, long ttl, TimeUnit unit) {
+        redisTemplate.opsForValue().set(key, value, ttl, unit);
+    }
+
+    @Override
+    public String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    @Override
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/ticketrush/infrastructure/waitingqueue/adapter/outbound/RedisWaitingQueueStoreAdapter.java
+++ b/src/main/java/com/ticketrush/infrastructure/waitingqueue/adapter/outbound/RedisWaitingQueueStoreAdapter.java
@@ -1,0 +1,142 @@
+package com.ticketrush.infrastructure.waitingqueue.adapter.outbound;
+
+import com.ticketrush.application.waitingqueue.port.outbound.WaitingQueueStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisWaitingQueueStoreAdapter implements WaitingQueueStore {
+
+    private static final DefaultRedisScript<List> JOIN_AND_RANK_SCRIPT;
+    private static final DefaultRedisScript<List> ACTIVATE_USERS_SCRIPT;
+
+    static {
+        JOIN_AND_RANK_SCRIPT = new DefaultRedisScript<>();
+        JOIN_AND_RANK_SCRIPT.setResultType(List.class);
+        JOIN_AND_RANK_SCRIPT.setScriptText("""
+                local queueKey = KEYS[1]
+                local activeKey = KEYS[2]
+                local userId = ARGV[1]
+                local score = tonumber(ARGV[2])
+                local maxQueueSize = tonumber(ARGV[3])
+
+                if redis.call('EXISTS', activeKey) == 1 then
+                    return {1, 0}
+                end
+
+                local existingRank = redis.call('ZRANK', queueKey, userId)
+                if existingRank then
+                    return {3, existingRank + 1}
+                end
+
+                local currentQueueSize = redis.call('ZCARD', queueKey)
+                if currentQueueSize >= maxQueueSize then
+                    return {2, -1}
+                end
+
+                redis.call('ZADD', queueKey, score, userId)
+                local addedRank = redis.call('ZRANK', queueKey, userId)
+                if addedRank then
+                    return {3, addedRank + 1}
+                end
+
+                return {4, -1}
+                """);
+
+        ACTIVATE_USERS_SCRIPT = new DefaultRedisScript<>();
+        ACTIVATE_USERS_SCRIPT.setResultType(List.class);
+        ACTIVATE_USERS_SCRIPT.setScriptText("""
+                local queueKey = KEYS[1]
+                local activeKeyPrefix = ARGV[1]
+                local ttlSeconds = tonumber(ARGV[2])
+                local count = tonumber(ARGV[3])
+
+                if count <= 0 then
+                    return {}
+                end
+
+                local popped = redis.call('ZPOPMIN', queueKey, count)
+                local activatedUsers = {}
+
+                for i = 1, #popped, 2 do
+                    local userId = popped[i]
+                    redis.call('SET', activeKeyPrefix .. userId, 'true', 'EX', ttlSeconds)
+                    table.insert(activatedUsers, userId)
+                end
+
+                return activatedUsers
+                """);
+    }
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public JoinAndRankResult joinAndRank(String queueKey, String activeKey, String userId, long score, long maxQueueSize) {
+        List<?> scriptResult = redisTemplate.execute(
+                JOIN_AND_RANK_SCRIPT,
+                List.of(queueKey, activeKey),
+                userId,
+                String.valueOf(score),
+                String.valueOf(maxQueueSize)
+        );
+        if (scriptResult == null || scriptResult.size() < 2) {
+            return null;
+        }
+        return new JoinAndRankResult(
+                toLong(scriptResult.get(0), 4L),
+                toLong(scriptResult.get(1), -1L)
+        );
+    }
+
+    @Override
+    public boolean hasActiveUser(String activeKey) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(activeKey));
+    }
+
+    @Override
+    public Long rank(String queueKey, String userId) {
+        return redisTemplate.opsForZSet().rank(queueKey, userId);
+    }
+
+    @Override
+    public List<String> activateUsers(String queueKey, String activeKeyPrefix, long ttlSeconds, long count) {
+        List<?> scriptResult = redisTemplate.execute(
+                ACTIVATE_USERS_SCRIPT,
+                List.of(queueKey),
+                activeKeyPrefix,
+                String.valueOf(ttlSeconds),
+                String.valueOf(count)
+        );
+        if (scriptResult == null || scriptResult.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> activatedUsers = new ArrayList<>(scriptResult.size());
+        for (Object value : scriptResult) {
+            if (value == null) {
+                continue;
+            }
+            activatedUsers.add(String.valueOf(value));
+        }
+        return activatedUsers;
+    }
+
+    @Override
+    public Long ttlSeconds(String key) {
+        return redisTemplate.getExpire(key, TimeUnit.SECONDS);
+    }
+
+    private long toLong(Object value, long defaultValue) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return defaultValue;
+    }
+}

--- a/src/test/java/com/ticketrush/application/reservation/service/SeatSoftLockServiceImplTest.java
+++ b/src/test/java/com/ticketrush/application/reservation/service/SeatSoftLockServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.application.reservation.service;
 
+import com.ticketrush.application.reservation.port.outbound.SeatSoftLockStore;
 import com.ticketrush.domain.entertainment.Entertainment;
 import com.ticketrush.domain.artist.Artist;
 import com.ticketrush.domain.concert.entity.Concert;
@@ -13,8 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -32,10 +31,7 @@ import static org.mockito.Mockito.when;
 class SeatSoftLockServiceImplTest {
 
     @Mock
-    private StringRedisTemplate redisTemplate;
-
-    @Mock
-    private ValueOperations<String, String> valueOperations;
+    private SeatSoftLockStore seatSoftLockStore;
 
     @Mock
     private ReservationSeatPort reservationSeatPort;
@@ -52,19 +48,18 @@ class SeatSoftLockServiceImplTest {
         reservationProperties.setSoftLockKeyPrefix("seat:lock:");
 
         seatSoftLockService = new SeatSoftLockServiceImpl(
-                redisTemplate,
+                seatSoftLockStore,
                 reservationSeatPort,
                 reservationProperties,
                 pushNotifier
         );
 
-        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         lenient().when(reservationSeatPort.getSeat(55L)).thenReturn(buildSeat(11L, 55L));
     }
 
     @Test
     void acquire_whenKeyIsEmpty_setsNxAndBroadcastsSelecting() {
-        when(valueOperations.setIfAbsent(
+        when(seatSoftLockStore.setIfAbsent(
                 eq("seat:lock:11:55"),
                 anyString(),
                 eq(30L),
@@ -85,7 +80,7 @@ class SeatSoftLockServiceImplTest {
 
     @Test
     void ensureHoldableByUser_whenForeignLockExists_throwsConflict() {
-        when(valueOperations.get("seat:lock:11:55")).thenReturn("999|req-x|2026-02-22T02:00:00Z");
+        when(seatSoftLockStore.get("seat:lock:11:55")).thenReturn("999|req-x|2026-02-22T02:00:00Z");
 
         assertThatThrownBy(() -> seatSoftLockService.ensureHoldableByUser(200L, 55L))
                 .isInstanceOf(IllegalStateException.class)
@@ -94,7 +89,7 @@ class SeatSoftLockServiceImplTest {
 
     @Test
     void release_whenOwnerMatches_deletesKeyAndBroadcastsReleased() {
-        when(valueOperations.get("seat:lock:11:55")).thenReturn("200|req-x|2026-02-22T02:00:00Z");
+        when(seatSoftLockStore.get("seat:lock:11:55")).thenReturn("200|req-x|2026-02-22T02:00:00Z");
 
         SeatSoftLockService.SeatSoftLockReleaseResult result = seatSoftLockService.release(200L, 55L);
 
@@ -102,7 +97,7 @@ class SeatSoftLockServiceImplTest {
         assertThat(result.seatId()).isEqualTo(55L);
         assertThat(result.status()).isEqualTo("RELEASED");
         assertThat(result.released()).isTrue();
-        verify(redisTemplate).delete("seat:lock:11:55");
+        verify(seatSoftLockStore).delete("seat:lock:11:55");
         verify(pushNotifier).sendSeatMapStatus(11L, 55L, "RELEASED", null, null);
     }
 
@@ -112,7 +107,7 @@ class SeatSoftLockServiceImplTest {
 
         seatSoftLockService.promoteToHold(200L, 55L, holdExpiresAt);
 
-        verify(redisTemplate).delete("seat:lock:11:55");
+        verify(seatSoftLockStore).delete("seat:lock:11:55");
         verify(pushNotifier).sendSeatMapStatus(
                 eq(11L),
                 eq(55L),

--- a/src/test/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImplTest.java
+++ b/src/test/java/com/ticketrush/application/waitingqueue/service/WaitingQueueServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.application.waitingqueue.service;
 
+import com.ticketrush.application.waitingqueue.port.outbound.WaitingQueueStore;
 import com.ticketrush.global.config.WaitingQueueProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -7,8 +8,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 import java.util.List;
 
@@ -24,7 +23,7 @@ import static org.mockito.Mockito.when;
 class WaitingQueueServiceImplTest {
 
     @Mock
-    private StringRedisTemplate redisTemplate;
+    private WaitingQueueStore waitingQueueStore;
 
     @Mock
     private WaitingQueueProperties properties;
@@ -41,23 +40,21 @@ class WaitingQueueServiceImplTest {
 
     @Test
     void activateUsers_executesLuaScriptAtomically() {
-        when(redisTemplate.execute(
-                any(DefaultRedisScript.class),
-                eq(List.of("waiting-queue:7")),
+        when(waitingQueueStore.activateUsers(
+                eq("waiting-queue:7"),
                 eq("active-user:"),
-                eq("300"),
-                eq("2")
+                eq(300L),
+                eq(2L)
         )).thenReturn(List.of("1001", "1002"));
 
         List<Long> activatedUsers = waitingQueueService.activateUsers(7L, 2);
 
         assertThat(activatedUsers).containsExactly(1001L, 1002L);
-        verify(redisTemplate).execute(
-                any(DefaultRedisScript.class),
-                eq(List.of("waiting-queue:7")),
+        verify(waitingQueueStore).activateUsers(
+                eq("waiting-queue:7"),
                 eq("active-user:"),
-                eq("300"),
-                eq("2")
+                eq(300L),
+                eq(2L)
         );
     }
 
@@ -66,12 +63,12 @@ class WaitingQueueServiceImplTest {
         List<Long> activatedUsers = waitingQueueService.activateUsers(7L, 0);
 
         assertThat(activatedUsers).isEmpty();
-        verifyNoInteractions(redisTemplate);
+        verifyNoInteractions(waitingQueueStore);
     }
 
     @Test
     void activateUsers_whenScriptReturnsNull_returnsEmpty() {
-        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(), any(), any()))
+        when(waitingQueueStore.activateUsers(any(), any(), any(Long.class), any(Long.class)))
                 .thenReturn(null);
 
         List<Long> activatedUsers = waitingQueueService.activateUsers(7L, 2);

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -36,6 +36,12 @@ class LayerDependencyArchTest {
                     .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.api..");
 
     @ArchTest
+    static final ArchRule application_should_not_depend_on_spring_redis_directly =
+            noClasses()
+                    .that().resideInAPackage("com.ticketrush.application..")
+                    .should().dependOnClassesThat().resideInAnyPackage("org.springframework.data.redis..");
+
+    @ArchTest
     static final ArchRule rest_controllers_should_not_depend_on_repository_directly =
             noClasses()
                     .that().areAnnotatedWith(RestController.class)


### PR DESCRIPTION
## Summary
- extract Redis-specific access out of application services via outbound ports
- add application ports:
  - `ReservationQueueStatusStore`
  - `SeatSoftLockStore`
  - `WaitingQueueStore`
- add infrastructure adapters:
  - `RedisReservationQueueStatusStoreAdapter`
  - `RedisSeatSoftLockStoreAdapter`
  - `RedisWaitingQueueStoreAdapter`
- switch `WaitingQueueServiceImpl`, `ReservationQueueServiceImpl`, `SeatSoftLockServiceImpl` to depend on ports
- update unit tests to mock ports instead of `StringRedisTemplate`
- add ArchUnit guardrail: application layer must not directly depend on `org.springframework.data.redis..`

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest' --tests 'com.ticketrush.application.waitingqueue.service.WaitingQueueServiceImplTest' --tests 'com.ticketrush.application.reservation.service.SeatSoftLockServiceImplTest' --tests 'com.ticketrush.global.scheduler.WaitingQueueSchedulerTest'`
- `./gradlew test --no-daemon --tests 'com.ticketrush.global.scheduler.ReservationLifecycleSchedulerTest' --tests 'com.ticketrush.application.reservation.service.ReservationLifecycleServiceIntegrationTest'`

## Tracking
- refs #33
