### PR TITLE
refactor: DDD Phase5-B global redis port-adapter split

### DIFF
--- a/src/main/java/com/ticketrush/global/interceptor/WaitingQueueInterceptor.java
+++ b/src/main/java/com/ticketrush/global/interceptor/WaitingQueueInterceptor.java
@@ -1,9 +1,9 @@
 package com.ticketrush.global.interceptor;
 
+import com.ticketrush.application.waitingqueue.port.outbound.WaitingQueueStore;
 import com.ticketrush.global.config.WaitingQueueProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -15,7 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @RequiredArgsConstructor
 public class WaitingQueueInterceptor implements HandlerInterceptor {
 
-    private final StringRedisTemplate redisTemplate;
+    private final WaitingQueueStore waitingQueueStore;
     private final WaitingQueueProperties waitingQueueProperties;
 
     @Override
@@ -29,9 +29,9 @@ public class WaitingQueueInterceptor implements HandlerInterceptor {
         }
 
         String activeKey = waitingQueueProperties.getActiveKeyPrefix() + userId;
-        Boolean isActive = redisTemplate.hasKey(activeKey);
+        boolean isActive = waitingQueueStore.hasActiveUser(activeKey);
 
-        if (Boolean.FALSE.equals(isActive)) {
+        if (!isActive) {
             log.warn(">>>> [Interceptor] 거부된 사용자: {}, 활성 토큰 없음", userId);
             response.sendError(HttpServletResponse.SC_FORBIDDEN, "Not an active user in waiting queue");
             return false;

--- a/src/main/java/com/ticketrush/global/push/WebSocketPushNotifier.java
+++ b/src/main/java/com/ticketrush/global/push/WebSocketPushNotifier.java
@@ -4,7 +4,6 @@ import com.ticketrush.global.config.WaitingQueueProperties;
 import com.ticketrush.global.sse.SseEventNames;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -15,7 +14,6 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component("webSocketPushNotifier")
@@ -27,29 +25,19 @@ public class WebSocketPushNotifier implements PushNotifier {
     private static final String SEAT_MAP_TOPIC_PREFIX = "/topic/seats";
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final StringRedisTemplate redisTemplate;
+    private final WebSocketQueueSubscriptionStore queueSubscriptionStore;
     private final WaitingQueueProperties waitingQueueProperties;
 
     public String subscribeQueue(Long userId, Long concertId) {
         long nowMillis = System.currentTimeMillis();
         long ttlSeconds = normalizedSubscriberTtlSeconds();
         long expiresAtMillis = nowMillis + (ttlSeconds * 1000L);
-        String subscriberKey = queueSubscriberKey(concertId);
-        redisTemplate.opsForZSet().add(subscriberKey, String.valueOf(userId), expiresAtMillis);
-        redisTemplate.opsForSet().add(concertIndexKey(), String.valueOf(concertId));
-        redisTemplate.expire(subscriberKey, ttlSeconds * 2, TimeUnit.SECONDS);
-        redisTemplate.expire(concertIndexKey(), ttlSeconds * 2, TimeUnit.SECONDS);
+        queueSubscriptionStore.addQueueSubscriber(concertId, userId, expiresAtMillis, ttlSeconds);
         return queueDestination(userId, concertId);
     }
 
     public void unsubscribeQueue(Long userId, Long concertId) {
-        String subscriberKey = queueSubscriberKey(concertId);
-        redisTemplate.opsForZSet().remove(subscriberKey, String.valueOf(userId));
-        Long size = redisTemplate.opsForZSet().zCard(subscriberKey);
-        if (size == null || size <= 0) {
-            redisTemplate.delete(subscriberKey);
-            redisTemplate.opsForSet().remove(concertIndexKey(), String.valueOf(concertId));
-        }
+        queueSubscriptionStore.removeQueueSubscriber(concertId, userId);
     }
 
     public String subscribeReservation(Long userId, Long seatId) {
@@ -95,7 +83,7 @@ public class WebSocketPushNotifier implements PushNotifier {
     @Override
     public void sendQueueHeartbeat() {
         String timestamp = Instant.now().toString();
-        Set<String> concertIdMembers = redisTemplate.opsForSet().members(concertIndexKey());
+        Set<String> concertIdMembers = queueSubscriptionStore.getConcertIds();
         if (concertIdMembers == null || concertIdMembers.isEmpty()) {
             return;
         }
@@ -112,7 +100,7 @@ public class WebSocketPushNotifier implements PushNotifier {
     }
 
     public Map<Long, Set<Long>> snapshotQueueSubscribers() {
-        Set<String> concertIdMembers = redisTemplate.opsForSet().members(concertIndexKey());
+        Set<String> concertIdMembers = queueSubscriptionStore.getConcertIds();
         if (concertIdMembers == null || concertIdMembers.isEmpty()) {
             return Collections.emptyMap();
         }
@@ -132,13 +120,9 @@ public class WebSocketPushNotifier implements PushNotifier {
 
     @Override
     public Set<Long> getSubscribedQueueUsers(Long concertId) {
-        String subscriberKey = queueSubscriberKey(concertId);
         long nowMillis = System.currentTimeMillis();
-        redisTemplate.opsForZSet().removeRangeByScore(subscriberKey, Double.NEGATIVE_INFINITY, nowMillis - 1);
-        Set<String> users = redisTemplate.opsForZSet().rangeByScore(subscriberKey, nowMillis, Double.POSITIVE_INFINITY);
+        Set<String> users = queueSubscriptionStore.getActiveSubscribers(concertId, nowMillis);
         if (users == null || users.isEmpty()) {
-            redisTemplate.opsForSet().remove(concertIndexKey(), String.valueOf(concertId));
-            redisTemplate.delete(subscriberKey);
             return Set.of();
         }
         Set<Long> parsed = new LinkedHashSet<>();
@@ -192,14 +176,6 @@ public class WebSocketPushNotifier implements PushNotifier {
 
     private String seatMapDestination(Long optionId) {
         return SEAT_MAP_TOPIC_PREFIX + "/" + optionId;
-    }
-
-    private String queueSubscriberKey(Long concertId) {
-        return waitingQueueProperties.getWsSubscriberZsetKeyPrefix() + concertId;
-    }
-
-    private String concertIndexKey() {
-        return waitingQueueProperties.getWsConcertIndexKey();
     }
 
     private long normalizedSubscriberTtlSeconds() {

--- a/src/main/java/com/ticketrush/global/push/WebSocketQueueSubscriptionStore.java
+++ b/src/main/java/com/ticketrush/global/push/WebSocketQueueSubscriptionStore.java
@@ -1,0 +1,14 @@
+package com.ticketrush.global.push;
+
+import java.util.Set;
+
+public interface WebSocketQueueSubscriptionStore {
+
+    void addQueueSubscriber(Long concertId, Long userId, long expiresAtMillis, long ttlSeconds);
+
+    void removeQueueSubscriber(Long concertId, Long userId);
+
+    Set<String> getConcertIds();
+
+    Set<String> getActiveSubscribers(Long concertId, long nowMillis);
+}

--- a/src/main/java/com/ticketrush/infrastructure/push/adapter/outbound/RedisWebSocketQueueSubscriptionStoreAdapter.java
+++ b/src/main/java/com/ticketrush/infrastructure/push/adapter/outbound/RedisWebSocketQueueSubscriptionStoreAdapter.java
@@ -1,0 +1,65 @@
+package com.ticketrush.infrastructure.push.adapter.outbound;
+
+import com.ticketrush.global.config.WaitingQueueProperties;
+import com.ticketrush.global.push.WebSocketQueueSubscriptionStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisWebSocketQueueSubscriptionStoreAdapter implements WebSocketQueueSubscriptionStore {
+
+    private final StringRedisTemplate redisTemplate;
+    private final WaitingQueueProperties waitingQueueProperties;
+
+    @Override
+    public void addQueueSubscriber(Long concertId, Long userId, long expiresAtMillis, long ttlSeconds) {
+        String subscriberKey = queueSubscriberKey(concertId);
+        redisTemplate.opsForZSet().add(subscriberKey, String.valueOf(userId), expiresAtMillis);
+        redisTemplate.opsForSet().add(concertIndexKey(), String.valueOf(concertId));
+        redisTemplate.expire(subscriberKey, ttlSeconds * 2, TimeUnit.SECONDS);
+        redisTemplate.expire(concertIndexKey(), ttlSeconds * 2, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void removeQueueSubscriber(Long concertId, Long userId) {
+        String subscriberKey = queueSubscriberKey(concertId);
+        redisTemplate.opsForZSet().remove(subscriberKey, String.valueOf(userId));
+        Long size = redisTemplate.opsForZSet().zCard(subscriberKey);
+        if (size == null || size <= 0) {
+            redisTemplate.delete(subscriberKey);
+            redisTemplate.opsForSet().remove(concertIndexKey(), String.valueOf(concertId));
+        }
+    }
+
+    @Override
+    public Set<String> getConcertIds() {
+        Set<String> concertIds = redisTemplate.opsForSet().members(concertIndexKey());
+        return concertIds == null ? Set.of() : concertIds;
+    }
+
+    @Override
+    public Set<String> getActiveSubscribers(Long concertId, long nowMillis) {
+        String subscriberKey = queueSubscriberKey(concertId);
+        redisTemplate.opsForZSet().removeRangeByScore(subscriberKey, Double.NEGATIVE_INFINITY, nowMillis - 1);
+        Set<String> users = redisTemplate.opsForZSet().rangeByScore(subscriberKey, nowMillis, Double.POSITIVE_INFINITY);
+        if (users == null || users.isEmpty()) {
+            redisTemplate.opsForSet().remove(concertIndexKey(), String.valueOf(concertId));
+            redisTemplate.delete(subscriberKey);
+            return Set.of();
+        }
+        return users;
+    }
+
+    private String queueSubscriberKey(Long concertId) {
+        return waitingQueueProperties.getWsSubscriberZsetKeyPrefix() + concertId;
+    }
+
+    private String concertIndexKey() {
+        return waitingQueueProperties.getWsConcertIndexKey();
+    }
+}

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -42,6 +42,12 @@ class LayerDependencyArchTest {
                     .should().dependOnClassesThat().resideInAnyPackage("org.springframework.data.redis..");
 
     @ArchTest
+    static final ArchRule global_should_not_depend_on_spring_redis_directly =
+            noClasses()
+                    .that().resideInAPackage("com.ticketrush.global..")
+                    .should().dependOnClassesThat().resideInAnyPackage("org.springframework.data.redis..");
+
+    @ArchTest
     static final ArchRule rest_controllers_should_not_depend_on_repository_directly =
             noClasses()
                     .that().areAnnotatedWith(RestController.class)

--- a/src/test/java/com/ticketrush/global/push/WebSocketPushNotifierTest.java
+++ b/src/test/java/com/ticketrush/global/push/WebSocketPushNotifierTest.java
@@ -2,16 +2,13 @@ package com.ticketrush.global.push;
 
 import com.ticketrush.global.config.WaitingQueueProperties;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.redis.core.SetOperations;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -21,35 +18,26 @@ import static org.mockito.Mockito.when;
 class WebSocketPushNotifierTest {
 
     @Test
-    void subscribeQueue_shouldPersistSubscriptionToRedis() {
+    void subscribeQueue_shouldPersistSubscriptionToStore() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
-        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
-        SetOperations<String, String> setOperations = mock(SetOperations.class);
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        WebSocketQueueSubscriptionStore subscriptionStore = mock(WebSocketQueueSubscriptionStore.class);
 
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, subscriptionStore, waitingQueueProperties());
 
         String destination = notifier.subscribeQueue(100L, 1L);
 
         assertThat(destination).isEqualTo("/topic/waiting-queue/1/100");
-        verify(zSetOperations).add(eq("ws:queue:subs:1"), eq("100"), anyDouble());
-        verify(setOperations).add("ws:queue:concerts", "1");
+        verify(subscriptionStore).addQueueSubscriber(eq(1L), eq(100L), anyLong(), eq(300L));
     }
 
     @Test
-    void getSubscribedQueueUsers_shouldReadFromRedis() {
+    void getSubscribedQueueUsers_shouldReadFromStore() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
-        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
-        SetOperations<String, String> setOperations = mock(SetOperations.class);
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-        when(redisTemplate.opsForSet()).thenReturn(setOperations);
-        when(zSetOperations.rangeByScore(eq("ws:queue:subs:1"), anyDouble(), anyDouble()))
+        WebSocketQueueSubscriptionStore subscriptionStore = mock(WebSocketQueueSubscriptionStore.class);
+        when(subscriptionStore.getActiveSubscribers(eq(1L), anyLong()))
                 .thenReturn(Set.of("100", "101"));
 
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, subscriptionStore, waitingQueueProperties());
 
         Set<Long> users = notifier.getSubscribedQueueUsers(1L);
 
@@ -59,16 +47,12 @@ class WebSocketPushNotifierTest {
     @Test
     void sendQueueHeartbeat_shouldPublishToSubscribedUsers() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
-        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
-        SetOperations<String, String> setOperations = mock(SetOperations.class);
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-        when(redisTemplate.opsForSet()).thenReturn(setOperations);
-        when(setOperations.members("ws:queue:concerts")).thenReturn(Set.of("1"));
-        when(zSetOperations.rangeByScore(eq("ws:queue:subs:1"), anyDouble(), anyDouble()))
+        WebSocketQueueSubscriptionStore subscriptionStore = mock(WebSocketQueueSubscriptionStore.class);
+        when(subscriptionStore.getConcertIds()).thenReturn(Set.of("1"));
+        when(subscriptionStore.getActiveSubscribers(eq(1L), anyLong()))
                 .thenReturn(Set.of("100"));
 
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, subscriptionStore, waitingQueueProperties());
 
         notifier.sendQueueHeartbeat();
 
@@ -78,13 +62,9 @@ class WebSocketPushNotifierTest {
     @Test
     void sendQueueActivated_shouldPublishToWaitingQueueTopic() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
-        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
-        SetOperations<String, String> setOperations = mock(SetOperations.class);
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        WebSocketQueueSubscriptionStore subscriptionStore = mock(WebSocketQueueSubscriptionStore.class);
 
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, subscriptionStore, waitingQueueProperties());
 
         notifier.sendQueueActivated(100L, 1L, Map.of("status", "ACTIVE"));
 
@@ -94,13 +74,9 @@ class WebSocketPushNotifierTest {
     @Test
     void sendReservationStatus_shouldPublishToReservationTopic() {
         SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
-        ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
-        SetOperations<String, String> setOperations = mock(SetOperations.class);
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        WebSocketQueueSubscriptionStore subscriptionStore = mock(WebSocketQueueSubscriptionStore.class);
 
-        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, redisTemplate, waitingQueueProperties());
+        WebSocketPushNotifier notifier = new WebSocketPushNotifier(messagingTemplate, subscriptionStore, waitingQueueProperties());
 
         notifier.sendReservationStatus(100L, 500L, "SUCCESS");
 


### PR DESCRIPTION
## Summary
- remove direct Redis client dependency from global components
- add `global.push.WebSocketQueueSubscriptionStore` interface
- add Redis adapter `infrastructure.push.adapter.outbound.RedisWebSocketQueueSubscriptionStoreAdapter`
- switch `WebSocketPushNotifier` to depend on queue subscription store interface
- switch `WaitingQueueInterceptor` to depend on `WaitingQueueStore` interface
- update `WebSocketPushNotifierTest` mocks to store interface
- add ArchUnit rule: global layer must not directly depend on `org.springframework.data.redis..`

## Verification
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest' --tests 'com.ticketrush.global.push.WebSocketPushNotifierTest' --tests 'com.ticketrush.global.scheduler.WaitingQueueSchedulerTest' --tests 'com.ticketrush.application.waitingqueue.service.WaitingQueueServiceImplTest'`
- `./gradlew test --no-daemon --tests 'com.ticketrush.application.reservation.service.SeatSoftLockServiceImplTest' --tests 'com.ticketrush.global.scheduler.ReservationLifecycleSchedulerTest' --tests 'com.ticketrush.application.reservation.service.ReservationLifecycleServiceIntegrationTest'`

## Tracking
- refs #33
