### PR TITLE
refactor: move kafka messaging implementations into infrastructure

### DIFF
--- a/src/main/java/com/ticketrush/api/controller/ReservationController.java
+++ b/src/main/java/com/ticketrush/api/controller/ReservationController.java
@@ -15,7 +15,7 @@ import com.ticketrush.application.reservation.service.AdminRefundAuditService;
 import com.ticketrush.application.reservation.service.ReservationLifecycleService;
 import com.ticketrush.application.reservation.service.SeatSoftLockService;
 import com.ticketrush.global.lock.RedissonLockFacade;
-import com.ticketrush.global.messaging.KafkaReservationProducer;
+import com.ticketrush.infrastructure.messaging.KafkaReservationProducer;
 import com.ticketrush.global.sse.SsePushNotifier;
 import com.ticketrush.api.dto.ReservationRequest;
 import com.ticketrush.api.dto.ReservationResponse;

--- a/src/main/java/com/ticketrush/global/push/KafkaWebSocketPushNotifier.java
+++ b/src/main/java/com/ticketrush/global/push/KafkaWebSocketPushNotifier.java
@@ -1,7 +1,7 @@
 package com.ticketrush.global.push;
 
-import com.ticketrush.global.messaging.KafkaPushEvent;
-import com.ticketrush.global.messaging.KafkaPushEventProducer;
+import com.ticketrush.infrastructure.messaging.KafkaPushEvent;
+import com.ticketrush.infrastructure.messaging.KafkaPushEventProducer;
 import com.ticketrush.global.sse.SseEventNames;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/ticketrush/infrastructure/messaging/KafkaPushEvent.java
+++ b/src/main/java/com/ticketrush/infrastructure/messaging/KafkaPushEvent.java
@@ -1,4 +1,4 @@
-package com.ticketrush.global.messaging;
+package com.ticketrush.infrastructure.messaging;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/ticketrush/infrastructure/messaging/KafkaPushEventConsumer.java
+++ b/src/main/java/com/ticketrush/infrastructure/messaging/KafkaPushEventConsumer.java
@@ -1,4 +1,4 @@
-package com.ticketrush.global.messaging;
+package com.ticketrush.infrastructure.messaging;
 
 import com.ticketrush.global.push.WebSocketPushNotifier;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ticketrush/infrastructure/messaging/KafkaPushEventProducer.java
+++ b/src/main/java/com/ticketrush/infrastructure/messaging/KafkaPushEventProducer.java
@@ -1,4 +1,4 @@
-package com.ticketrush.global.messaging;
+package com.ticketrush.infrastructure.messaging;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/ticketrush/infrastructure/messaging/KafkaReservationConsumer.java
+++ b/src/main/java/com/ticketrush/infrastructure/messaging/KafkaReservationConsumer.java
@@ -1,4 +1,4 @@
-package com.ticketrush.global.messaging;
+package com.ticketrush.infrastructure.messaging;
 
 import com.ticketrush.application.reservation.model.ReservationCreateCommand;
 import com.ticketrush.application.reservation.model.ReservationQueueEvent;

--- a/src/main/java/com/ticketrush/infrastructure/messaging/KafkaReservationProducer.java
+++ b/src/main/java/com/ticketrush/infrastructure/messaging/KafkaReservationProducer.java
@@ -1,4 +1,4 @@
-package com.ticketrush.global.messaging;
+package com.ticketrush.infrastructure.messaging;
 
 import com.ticketrush.application.reservation.model.ReservationQueueEvent;
 import com.ticketrush.application.reservation.model.ReservationQueueLockType;

--- a/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
+++ b/src/test/java/com/ticketrush/architecture/LayerDependencyArchTest.java
@@ -48,6 +48,12 @@ class LayerDependencyArchTest {
                     .should().dependOnClassesThat().resideInAnyPackage("org.springframework.data.redis..");
 
     @ArchTest
+    static final ArchRule global_should_not_depend_on_spring_kafka_directly =
+            noClasses()
+                    .that().resideInAPackage("com.ticketrush.global..")
+                    .should().dependOnClassesThat().resideInAnyPackage("org.springframework.kafka..");
+
+    @ArchTest
     static final ArchRule rest_controllers_should_not_depend_on_repository_directly =
             noClasses()
                     .that().areAnnotatedWith(RestController.class)
@@ -99,8 +105,8 @@ class LayerDependencyArchTest {
                     .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.payment.service..");
 
     @ArchTest
-    static final ArchRule global_messaging_should_not_depend_on_domain_reservation_events =
+    static final ArchRule infrastructure_messaging_should_not_depend_on_domain_reservation_events =
             noClasses()
-                    .that().resideInAPackage("com.ticketrush.global.messaging..")
+                    .that().resideInAPackage("com.ticketrush.infrastructure.messaging..")
                     .should().dependOnClassesThat().resideInAnyPackage("com.ticketrush.domain.reservation.event..");
 }

--- a/src/test/java/com/ticketrush/global/push/KafkaWebSocketPushNotifierTest.java
+++ b/src/test/java/com/ticketrush/global/push/KafkaWebSocketPushNotifierTest.java
@@ -1,7 +1,7 @@
 package com.ticketrush.global.push;
 
-import com.ticketrush.global.messaging.KafkaPushEvent;
-import com.ticketrush.global.messaging.KafkaPushEventProducer;
+import com.ticketrush.infrastructure.messaging.KafkaPushEvent;
+import com.ticketrush.infrastructure.messaging.KafkaPushEventProducer;
 import com.ticketrush.global.sse.SseEventNames;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ticketrush/infrastructure/messaging/KafkaPushEventConsumerTest.java
+++ b/src/test/java/com/ticketrush/infrastructure/messaging/KafkaPushEventConsumerTest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.global.messaging;
+package com.ticketrush.infrastructure.messaging;
 
 import com.ticketrush.global.push.WebSocketPushNotifier;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- relocate Kafka messaging classes from `global.messaging` to `infrastructure.messaging`
- update controller/notifier/test imports to new package path
- harden ArchUnit rule: `global..` must not depend on `org.springframework.kafka..`

## Verification
- ./gradlew compileJava compileTestJava --no-daemon
- ./gradlew test --no-daemon --tests 'com.ticketrush.architecture.LayerDependencyArchTest' --tests 'com.ticketrush.infrastructure.messaging.KafkaPushEventConsumerTest' --tests 'com.ticketrush.global.push.KafkaWebSocketPushNotifierTest' --tests 'com.ticketrush.global.scheduler.ReservationLifecycleSchedulerTest' --tests 'com.ticketrush.application.reservation.service.ReservationLifecycleServiceIntegrationTest'

## Issue
- refs #33
