### PR TITLE
feat(concert): support seat-layout template creation and natural seat sorting

### DIFF
--- a/scripts/api/setup-test-data.sh
+++ b/scripts/api/setup-test-data.sh
@@ -18,6 +18,7 @@ NC='\033[0m'
 CONCERT_TITLE="TEST_CONCERT_$(date +%s)"
 CONCERT_DATE=$(date -d "+10 days" +"%Y-%m-%dT%H:%M:%S")
 OPTION_COUNT="${OPTION_COUNT:-2}"
+USE_SEAT_LAYOUT="${USE_SEAT_LAYOUT:-0}"
 SUFFIX=$(date +%s)
 ENTERTAINMENT_NAME="TEST_AGENCY_${SUFFIX}"
 ARTIST_NAME="TEST_ARTIST_${SUFFIX}"
@@ -61,16 +62,36 @@ if [ "${USE_DOMAIN_CRUD}" = "1" ]; then
 fi
 
 # 1. 공연 및 좌석 생성
+if [ "${USE_SEAT_LAYOUT}" = "1" ]; then
+    SETUP_PAYLOAD="{
+      \"title\": \"${CONCERT_TITLE}\",
+      \"artistName\": \"${ARTIST_NAME}\",
+      \"entertainmentName\": \"${ENTERTAINMENT_NAME}\",
+      \"concertDate\": \"${CONCERT_DATE}\",
+      \"seatCount\": 0,
+      \"seatLayout\": {
+        \"sections\": [
+          {\"code\": \"A\", \"rows\": [{\"label\": \"R\", \"from\": 1, \"to\": 20}]},
+          {\"code\": \"B\", \"rows\": [{\"label\": \"R\", \"from\": 1, \"to\": 20}]},
+          {\"code\": \"C\", \"capacity\": 10}
+        ]
+      },
+      \"optionCount\": ${OPTION_COUNT}
+    }"
+else
+    SETUP_PAYLOAD="{
+      \"title\": \"${CONCERT_TITLE}\",
+      \"artistName\": \"${ARTIST_NAME}\",
+      \"entertainmentName\": \"${ENTERTAINMENT_NAME}\",
+      \"concertDate\": \"${CONCERT_DATE}\",
+      \"seatCount\": 50,
+      \"optionCount\": ${OPTION_COUNT}
+    }"
+fi
+
 RESPONSE=$(curl -s -X POST "${SETUP_API}" \
      -H "${CONTENT_TYPE}" \
-     -d "{
-       \"title\": \"${CONCERT_TITLE}\",
-       \"artistName\": \"${ARTIST_NAME}\",
-       \"entertainmentName\": \"${ENTERTAINMENT_NAME}\",
-       \"concertDate\": \"${CONCERT_DATE}\",
-       \"seatCount\": 50,
-       \"optionCount\": ${OPTION_COUNT}
-     }")
+     -d "${SETUP_PAYLOAD}")
 
 echo -e "Response: ${RESPONSE}"
 

--- a/src/main/java/com/ticketrush/api/controller/AdminConcertController.java
+++ b/src/main/java/com/ticketrush/api/controller/AdminConcertController.java
@@ -122,7 +122,9 @@ public class AdminConcertController {
                 )
         );
         int seatCount = request.getSeatCount() == null ? 0 : request.getSeatCount();
-        if (seatCount > 0) {
+        if (request.getSeatLayout() != null) {
+            concertUseCase.createSeats(response.getId(), request.getSeatLayout().toCommand());
+        } else if (seatCount > 0) {
             concertUseCase.createSeats(response.getId(), seatCount);
         }
         return ResponseEntity.status(201).body(response);

--- a/src/main/java/com/ticketrush/api/controller/ConcertController.java
+++ b/src/main/java/com/ticketrush/api/controller/ConcertController.java
@@ -65,7 +65,11 @@ public class ConcertController {
                     request.getConcertDate().plusDays(index),
                     null
             );
-            concertUseCase.createSeats(option.getId(), request.getSeatCount());
+            if (request.getSeatLayout() != null) {
+                concertUseCase.createSeats(option.getId(), request.getSeatLayout().toCommand());
+            } else if (request.getSeatCount() > 0) {
+                concertUseCase.createSeats(option.getId(), request.getSeatCount());
+            }
             optionIds.add(option.getId());
         }
 

--- a/src/main/java/com/ticketrush/api/dto/ConcertSetupRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/ConcertSetupRequest.java
@@ -31,5 +31,6 @@ public class ConcertSetupRequest {
     private String venueAddress;
     private LocalDateTime concertDate;
     private int seatCount;
+    private SeatLayoutRequest seatLayout;
     private int optionCount;
 }

--- a/src/main/java/com/ticketrush/api/dto/SeatLayoutRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/SeatLayoutRequest.java
@@ -1,0 +1,24 @@
+package com.ticketrush.api.dto;
+
+import com.ticketrush.application.concert.model.SeatLayoutCommand;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatLayoutRequest {
+    private List<SeatLayoutSectionRequest> sections;
+
+    public SeatLayoutCommand toCommand() {
+        List<SeatLayoutCommand.Section> mappedSections = sections == null
+                ? List.of()
+                : sections.stream()
+                .map(SeatLayoutSectionRequest::toCommand)
+                .toList();
+        return new SeatLayoutCommand(mappedSections);
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/SeatLayoutRowRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/SeatLayoutRowRequest.java
@@ -1,0 +1,19 @@
+package com.ticketrush.api.dto;
+
+import com.ticketrush.application.concert.model.SeatLayoutCommand;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatLayoutRowRequest {
+    private String label;
+    private Integer from;
+    private Integer to;
+
+    public SeatLayoutCommand.Row toCommand() {
+        return new SeatLayoutCommand.Row(label, from, to);
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/SeatLayoutSectionRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/SeatLayoutSectionRequest.java
@@ -1,0 +1,26 @@
+package com.ticketrush.api.dto;
+
+import com.ticketrush.application.concert.model.SeatLayoutCommand;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatLayoutSectionRequest {
+    private String code;
+    private Integer capacity;
+    private List<SeatLayoutRowRequest> rows;
+
+    public SeatLayoutCommand.Section toCommand() {
+        List<SeatLayoutCommand.Row> mappedRows = rows == null
+                ? List.of()
+                : rows.stream()
+                .map(SeatLayoutRowRequest::toCommand)
+                .toList();
+        return new SeatLayoutCommand.Section(code, capacity, mappedRows);
+    }
+}

--- a/src/main/java/com/ticketrush/api/dto/admin/AdminConcertOptionCreateRequest.java
+++ b/src/main/java/com/ticketrush/api/dto/admin/AdminConcertOptionCreateRequest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.api.dto.admin;
 
+import com.ticketrush.api.dto.SeatLayoutRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 public class AdminConcertOptionCreateRequest {
     private LocalDateTime concertDate;
     private Integer seatCount;
+    private SeatLayoutRequest seatLayout;
     private Long ticketPriceAmount;
     private Long venueId;
 }

--- a/src/main/java/com/ticketrush/application/concert/model/SeatLayoutCommand.java
+++ b/src/main/java/com/ticketrush/application/concert/model/SeatLayoutCommand.java
@@ -1,0 +1,35 @@
+package com.ticketrush.application.concert.model;
+
+import java.util.List;
+
+public record SeatLayoutCommand(List<Section> sections) {
+
+    public static SeatLayoutCommand singleSectionCount(int seatCount) {
+        if (seatCount <= 0) {
+            throw new IllegalArgumentException("seatCount must be greater than 0");
+        }
+        return new SeatLayoutCommand(
+                List.of(
+                        new Section(
+                                "A",
+                                seatCount,
+                                List.of()
+                        )
+                )
+        );
+    }
+
+    public record Section(
+            String code,
+            Integer capacity,
+            List<Row> rows
+    ) {
+    }
+
+    public record Row(
+            String label,
+            Integer from,
+            Integer to
+    ) {
+    }
+}

--- a/src/main/java/com/ticketrush/application/concert/port/inbound/ConcertUseCase.java
+++ b/src/main/java/com/ticketrush/application/concert/port/inbound/ConcertUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.application.concert.port.inbound;
 
+import com.ticketrush.application.concert.model.SeatLayoutCommand;
 import com.ticketrush.application.concert.model.ConcertOptionResult;
 import com.ticketrush.application.concert.model.ConcertResult;
 import com.ticketrush.application.concert.model.SeatResult;
@@ -195,6 +196,7 @@ public interface ConcertUseCase {
     void deleteOption(Long optionId);
 
     void createSeats(Long optionId, int count);
+    void createSeats(Long optionId, SeatLayoutCommand seatLayout);
 
     void deleteConcert(Long concertId);
 

--- a/src/main/java/com/ticketrush/application/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/com/ticketrush/application/concert/service/ConcertServiceImpl.java
@@ -2,6 +2,7 @@ package com.ticketrush.application.concert.service;
 
 import com.ticketrush.application.concert.model.ConcertOptionResult;
 import com.ticketrush.application.concert.model.ConcertResult;
+import com.ticketrush.application.concert.model.SeatLayoutCommand;
 import com.ticketrush.application.concert.model.SeatResult;
 import com.ticketrush.application.concert.port.outbound.ConcertReadCacheEvictPort;
 import com.ticketrush.domain.entertainment.Entertainment;
@@ -27,12 +28,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +48,9 @@ public class ConcertServiceImpl implements ConcertService {
     private static final String CACHE_CONCERT_SEARCH = "concert:search";
     private static final String CACHE_CONCERT_OPTIONS = "concert:options";
     private static final String CACHE_CONCERT_AVAILABLE_SEATS = "concert:available-seats";
+    private static final Pattern NATURAL_TOKEN_PATTERN = Pattern.compile("\\d+|\\D+");
+    private static final Comparator<Seat> SEAT_NUMBER_COMPARATOR =
+            Comparator.comparing(Seat::getSeatNumber, ConcertServiceImpl::compareNaturalStrings);
 
     private final ConcertRepository concertRepository;
     private final ConcertOptionRepository concertOptionRepository;
@@ -121,7 +131,9 @@ public class ConcertServiceImpl implements ConcertService {
     @Transactional(readOnly = true)
     @Cacheable(cacheNames = CACHE_CONCERT_AVAILABLE_SEATS, key = "#concertOptionId")
     public List<Seat> getAvailableSeats(Long concertOptionId) {
-        return seatRepository.findByConcertOptionIdAndStatus(concertOptionId, Seat.SeatStatus.AVAILABLE);
+        List<Seat> seats = seatRepository.findByConcertOptionIdAndStatus(concertOptionId, Seat.SeatStatus.AVAILABLE);
+        seats.sort(SEAT_NUMBER_COMPARATOR);
+        return seats;
     }
 
     @Override
@@ -138,8 +150,9 @@ public class ConcertServiceImpl implements ConcertService {
     public List<SeatResult> getSeatMapResults(Long concertOptionId, List<String> statuses) {
         Set<Seat.SeatStatus> targetStatuses = parseSeatStatuses(statuses);
         List<Seat> seats = targetStatuses.isEmpty()
-                ? seatRepository.findByConcertOptionIdOrderBySeatNumberAsc(concertOptionId)
-                : seatRepository.findByConcertOptionIdAndStatusInOrderBySeatNumberAsc(concertOptionId, targetStatuses);
+                ? seatRepository.findByConcertOptionId(concertOptionId)
+                : seatRepository.findByConcertOptionIdAndStatusIn(concertOptionId, targetStatuses);
+        seats.sort(SEAT_NUMBER_COMPARATOR);
         return seats.stream()
                 .map(SeatResult::from)
                 .toList();
@@ -568,11 +581,25 @@ public class ConcertServiceImpl implements ConcertService {
             @CacheEvict(cacheNames = CACHE_CONCERT_AVAILABLE_SEATS, allEntries = true)
     })
     public void createSeats(Long optionId, int count) {
+        if (count <= 0) {
+            return;
+        }
+        createSeats(optionId, SeatLayoutCommand.singleSectionCount(count));
+    }
+
+    @Override
+    @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CACHE_CONCERT_LIST, allEntries = true),
+            @CacheEvict(cacheNames = CACHE_CONCERT_OPTIONS, allEntries = true),
+            @CacheEvict(cacheNames = CACHE_CONCERT_SEARCH, allEntries = true),
+            @CacheEvict(cacheNames = CACHE_CONCERT_AVAILABLE_SEATS, allEntries = true)
+    })
+    public void createSeats(Long optionId, SeatLayoutCommand seatLayout) {
         ConcertOption option = concertOptionRepository.findById(optionId)
                 .orElseThrow(() -> new IllegalArgumentException("Concert option not found"));
-        for (int i = 1; i <= count; i++) {
-            seatRepository.save(new Seat(option, "A-" + i));
-        }
+        List<Seat> seats = buildSeatsFromLayout(option, seatLayout);
+        seatRepository.saveAll(seats);
         concertReadCacheEvictPort.evictConcertCards();
     }
 
@@ -677,6 +704,112 @@ public class ConcertServiceImpl implements ConcertService {
             }
         }
         return parsed;
+    }
+
+    private List<Seat> buildSeatsFromLayout(ConcertOption option, SeatLayoutCommand seatLayout) {
+        if (seatLayout == null || seatLayout.sections() == null || seatLayout.sections().isEmpty()) {
+            throw new IllegalArgumentException("seatLayout.sections is required");
+        }
+        List<Seat> seats = new ArrayList<>();
+        Set<String> seenSeatNumbers = new HashSet<>();
+        for (SeatLayoutCommand.Section section : seatLayout.sections()) {
+            String sectionCode = normalizeRequired(section.code(), "seatLayout.sections[].code");
+            List<SeatLayoutCommand.Row> rows = section.rows() == null ? List.of() : section.rows();
+            if (!rows.isEmpty()) {
+                for (SeatLayoutCommand.Row row : rows) {
+                    String rowLabel = normalizeRequired(row.label(), "seatLayout.sections[].rows[].label");
+                    Integer from = row.from();
+                    Integer to = row.to();
+                    if (from == null || to == null || from <= 0 || to <= 0 || from > to) {
+                        throw new IllegalArgumentException("invalid seat range in seatLayout row");
+                    }
+                    for (int seatNo = from; seatNo <= to; seatNo++) {
+                        String seatNumber = sectionCode + "-" + rowLabel + "-" + seatNo;
+                        addSeat(option, seats, seenSeatNumbers, seatNumber);
+                    }
+                }
+                continue;
+            }
+            Integer capacity = section.capacity();
+            if (capacity == null || capacity <= 0) {
+                throw new IllegalArgumentException("seatLayout section requires rows or positive capacity");
+            }
+            for (int seatNo = 1; seatNo <= capacity; seatNo++) {
+                String seatNumber = sectionCode + "-" + seatNo;
+                addSeat(option, seats, seenSeatNumbers, seatNumber);
+            }
+        }
+        if (seats.isEmpty()) {
+            throw new IllegalArgumentException("seatLayout must generate at least one seat");
+        }
+        return seats;
+    }
+
+    private void addSeat(ConcertOption option, List<Seat> target, Set<String> seenSeatNumbers, String seatNumber) {
+        String dedupeKey = seatNumber.toUpperCase(Locale.ROOT);
+        if (!seenSeatNumbers.add(dedupeKey)) {
+            throw new IllegalArgumentException("duplicated seat number in seatLayout: " + seatNumber);
+        }
+        target.add(new Seat(option, seatNumber));
+    }
+
+    private static int compareNaturalStrings(String left, String right) {
+        if (left == null && right == null) {
+            return 0;
+        }
+        if (left == null) {
+            return -1;
+        }
+        if (right == null) {
+            return 1;
+        }
+
+        List<String> leftTokens = tokenizeNatural(left);
+        List<String> rightTokens = tokenizeNatural(right);
+        int max = Math.max(leftTokens.size(), rightTokens.size());
+        for (int index = 0; index < max; index++) {
+            if (index >= leftTokens.size()) {
+                return -1;
+            }
+            if (index >= rightTokens.size()) {
+                return 1;
+            }
+            String l = leftTokens.get(index);
+            String r = rightTokens.get(index);
+            boolean lDigit = isAllDigits(l);
+            boolean rDigit = isAllDigits(r);
+            int compared;
+            if (lDigit && rDigit) {
+                compared = new BigInteger(l).compareTo(new BigInteger(r));
+            } else {
+                compared = l.compareToIgnoreCase(r);
+                if (compared == 0) {
+                    compared = l.compareTo(r);
+                }
+            }
+            if (compared != 0) {
+                return compared;
+            }
+        }
+        return 0;
+    }
+
+    private static List<String> tokenizeNatural(String value) {
+        List<String> tokens = new ArrayList<>();
+        Matcher matcher = NATURAL_TOKEN_PATTERN.matcher(value);
+        while (matcher.find()) {
+            tokens.add(matcher.group());
+        }
+        return tokens;
+    }
+
+    private static boolean isAllDigits(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            if (!Character.isDigit(value.charAt(index))) {
+                return false;
+            }
+        }
+        return !value.isEmpty();
     }
 
     private String normalizeLower(String value) {

--- a/src/main/java/com/ticketrush/domain/concert/repository/SeatRepository.java
+++ b/src/main/java/com/ticketrush/domain/concert/repository/SeatRepository.java
@@ -18,8 +18,8 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     Optional<Seat> findByIdWithPessimisticLock(@Param("id") Long id);
 
     List<Seat> findByConcertOptionIdAndStatus(Long concertOptionId, Seat.SeatStatus status);
-    List<Seat> findByConcertOptionIdOrderBySeatNumberAsc(Long concertOptionId);
-    List<Seat> findByConcertOptionIdAndStatusInOrderBySeatNumberAsc(Long concertOptionId, Collection<Seat.SeatStatus> statuses);
+    List<Seat> findByConcertOptionId(Long concertOptionId);
+    List<Seat> findByConcertOptionIdAndStatusIn(Long concertOptionId, Collection<Seat.SeatStatus> statuses);
     boolean existsByConcertOptionId(Long concertOptionId);
 
     @Query("""

--- a/src/test/java/com/ticketrush/application/concert/service/ConcertExplorerIntegrationTest.java
+++ b/src/test/java/com/ticketrush/application/concert/service/ConcertExplorerIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.ticketrush.application.concert.service;
 
+import com.ticketrush.application.concert.model.SeatLayoutCommand;
+import com.ticketrush.application.concert.model.SeatResult;
 import com.ticketrush.application.reservation.model.ReservationCreateCommand;
 import com.ticketrush.application.reservation.model.SalesPolicyUpsertCommand;
 import com.ticketrush.application.reservation.port.inbound.SalesPolicyUseCase;
@@ -15,17 +17,21 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -184,5 +190,95 @@ class ConcertExplorerIntegrationTest {
                 .andExpect(jsonPath("$.sellOutRiskRatioThreshold").value(18))
                 .andExpect(content().string(containsString("Highlights Soon Concert")))
                 .andExpect(content().string(containsString("Highlights Low Stock Concert")));
+    }
+
+    @Test
+    void seatMapSupportsLayoutInputAndNaturalSortOrder() {
+        var concert = concertService.createConcert("Layout Sort Concert", "Layout Artist", "Layout Entertainment");
+        var option = concertService.addOption(concert.getId(), LocalDateTime.now().plusDays(1));
+
+        concertService.createSeats(
+                option.getId(),
+                new SeatLayoutCommand(
+                        List.of(
+                                new SeatLayoutCommand.Section(
+                                        "B",
+                                        null,
+                                        List.of(new SeatLayoutCommand.Row("A", 1, 2))
+                                ),
+                                new SeatLayoutCommand.Section(
+                                        "A",
+                                        null,
+                                        List.of(new SeatLayoutCommand.Row("A", 1, 12))
+                                )
+                        )
+                )
+        );
+
+        List<String> seatNumbers = concertService.getSeatMapResults(option.getId(), List.of("AVAILABLE")).stream()
+                .map(SeatResult::getSeatNumber)
+                .toList();
+
+        List<String> expected = new ArrayList<>();
+        for (int seatNo = 1; seatNo <= 12; seatNo++) {
+            expected.add("A-A-" + seatNo);
+        }
+        expected.add("B-A-1");
+        expected.add("B-A-2");
+
+        assertThat(seatNumbers).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void legacySeatCountCreationRemainsCompatible() {
+        var concert = concertService.createConcert("Legacy Seat Concert", "Legacy Artist", "Legacy Entertainment");
+        var option = concertService.addOption(concert.getId(), LocalDateTime.now().plusDays(1));
+
+        concertService.createSeats(option.getId(), 3);
+
+        List<String> seatNumbers = concertService.getSeatMapResults(option.getId(), List.of("AVAILABLE")).stream()
+                .map(SeatResult::getSeatNumber)
+                .toList();
+
+        assertThat(seatNumbers).containsExactly("A-1", "A-2", "A-3");
+    }
+
+    @Test
+    void setupConcertSupportsSeatLayoutPayload() throws Exception {
+        String title = "Setup Layout Concert " + System.nanoTime();
+        String concertDate = LocalDateTime.now().plusDays(2).withNano(0).toString();
+
+        String requestBody = """
+                {
+                  "title": "%s",
+                  "artistName": "Setup Layout Artist",
+                  "entertainmentName": "Setup Layout Entertainment",
+                  "concertDate": "%s",
+                  "seatCount": 0,
+                  "optionCount": 1,
+                  "seatLayout": {
+                    "sections": [
+                      {"code": "VIP", "rows": [{"label": "R", "from": 1, "to": 2}]},
+                      {"code": "GA", "capacity": 2}
+                    ]
+                  }
+                }
+                """.formatted(title, concertDate);
+
+        MvcResult result = mockMvc.perform(post("/api/concerts/setup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("OptionID=")))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        Long optionId = Long.parseLong(body.replaceAll(".*OptionID=(\\d+).*", "$1"));
+
+        List<String> seatNumbers = concertService.getSeatMapResults(optionId, List.of("AVAILABLE")).stream()
+                .map(SeatResult::getSeatNumber)
+                .toList();
+
+        assertThat(seatNumbers).containsExactly("GA-1", "GA-2", "VIP-R-1", "VIP-R-2");
     }
 }


### PR DESCRIPTION
## Summary
- 옵션 좌석 생성에 `seatLayout` 입력을 추가해 섹션/행/좌석 범위 또는 섹션 capacity 기반 생성 지원
- 기존 `seatCount` 경로는 하위호환 유지 (`A-1..A-N`)
- seat-map/available seats 정렬을 문자열 정렬에서 natural sort로 전환
- setup-test-data 스크립트에 `USE_SEAT_LAYOUT=1` 시나리오 추가

## API Changes
- `POST /api/admin/concerts/{concertId}/options` request에 `seatLayout` optional 추가
- `POST /api/concerts/setup` request에 `seatLayout` optional 추가

## Validation
- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew test --no-daemon --tests 'com.ticketrush.application.concert.service.ConcertExplorerIntegrationTest' --tests 'com.ticketrush.architecture.LayerDependencyArchTest'`

Closes #57
