### PR TITLE
refactor(seed): load kpop20 demo dataset from json source

### DIFF
--- a/scripts/api/data/kpop20-demo-dataset.json
+++ b/scripts/api/data/kpop20-demo-dataset.json
@@ -1,0 +1,170 @@
+[
+  {
+    "artist": "Stray Kids",
+    "entertainment": "JYP Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=0P0aQreFs8w",
+    "seatCount": 260,
+    "saleBucket": "OPEN_SOON_5M"
+  },
+  {
+    "artist": "BTS",
+    "entertainment": "BIGHIT MUSIC",
+    "youtubeUrl": "https://www.youtube.com/watch?v=gdZLi9oWNZg",
+    "seatCount": 320,
+    "saleBucket": "OPEN"
+  },
+  {
+    "artist": "Saja Boys",
+    "entertainment": "Netflix",
+    "youtubeUrl": "https://www.youtube.com/watch?v=2FS3JAPTKXs",
+    "seatCount": 180,
+    "saleBucket": "OPEN"
+  },
+  {
+    "artist": "BLACKPINK",
+    "entertainment": "YG Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=IHNzOHi8sJs",
+    "seatCount": 300,
+    "saleBucket": "OPEN"
+  },
+  {
+    "artist": "NewJeans",
+    "entertainment": "ADOR",
+    "youtubeUrl": "https://youtu.be/DAEK5GrLb_Y?si=rhJGnEY4sB0jay5s",
+    "seatCount": 260,
+    "saleBucket": "OPEN_SOON_1H"
+  },
+  {
+    "artist": "LE SSERAFIM",
+    "entertainment": "SOURCE MUSIC",
+    "youtubeUrl": "https://youtu.be/hLvWy2b857I?si=aS73yFYIc0l53Cyo",
+    "seatCount": 240,
+    "saleBucket": "OPEN_SOON_1H"
+  },
+  {
+    "artist": "TOMORROW X TOGETHER",
+    "entertainment": "BIGHIT MUSIC",
+    "youtubeUrl": "https://youtu.be/C0EYKxF1oTI?si=p6Wn2VSfC2R0jNPX",
+    "seatCount": 230,
+    "saleBucket": "OPEN_SOON_1H"
+  },
+  {
+    "artist": "ITZY",
+    "entertainment": "JYP Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=fE2h3lGlOsk",
+    "seatCount": 220,
+    "saleBucket": "PREOPEN"
+  },
+  {
+    "artist": "TWICE",
+    "entertainment": "JYP Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=i0p1bmr0EmE",
+    "seatCount": 280,
+    "saleBucket": "PREOPEN"
+  },
+  {
+    "artist": "SEVENTEEN",
+    "entertainment": "PLEDIS Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=-GQg25oP0S4",
+    "seatCount": 280,
+    "saleBucket": "PREOPEN"
+  },
+  {
+    "artist": "HUNTRIX",
+    "entertainment": "Sony Animation",
+    "youtubeUrl": "https://www.youtube.com/watch?v=yebNIHKAC4A",
+    "seatCount": 170,
+    "saleBucket": "SOLD_OUT"
+  },
+  {
+    "artist": "BIGBANG",
+    "entertainment": "YG Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=2ips2mM7Zqw",
+    "seatCount": 220,
+    "saleBucket": "SOLD_OUT"
+  },
+  {
+    "artist": "BABYMONSTER",
+    "entertainment": "YG Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=2wA_b6YHjqQ",
+    "seatCount": 210,
+    "saleBucket": "SOLD_OUT"
+  },
+  {
+    "artist": "KARA",
+    "entertainment": "DSP Media",
+    "youtubeUrl": "https://www.youtube.com/watch?v=XwcK-twSXB4",
+    "seatCount": 170,
+    "saleBucket": "SOLD_OUT"
+  },
+  {
+    "artist": "MAMAMOO",
+    "entertainment": "RBW",
+    "youtubeUrl": "https://www.youtube.com/watch?v=KhTeiaCezwM",
+    "seatCount": 200,
+    "saleBucket": "SOLD_OUT"
+  },
+  {
+    "artist": "(G)I-DLE",
+    "entertainment": "CUBE Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=Jh4QFaPmdss",
+    "seatCount": 230,
+    "saleBucket": "SOLD_OUT"
+  },
+  {
+    "artist": "NMIXX",
+    "entertainment": "JYP Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=Rd2wppggYxo",
+    "seatCount": 200,
+    "saleBucket": "SOLD_OUT"
+  },
+  {
+    "artist": "aespa",
+    "entertainment": "SM Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=4TWR90KJl84",
+    "seatCount": 250,
+    "saleBucket": "UNSCHEDULED"
+  },
+  {
+    "artist": "IVE",
+    "entertainment": "STARSHIP Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=6ZUIwj3FgUY",
+    "seatCount": 240,
+    "saleBucket": "OPEN_SOON_1H"
+  },
+  {
+    "artist": "STAYC",
+    "entertainment": "High Up Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=SxHmoifp0oQ",
+    "seatCount": 190,
+    "saleBucket": "OPEN_SOON_1H"
+  },
+  {
+    "artist": "KISS OF LIFE",
+    "entertainment": "S2 Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=oKVYm8mIUdo",
+    "seatCount": 180,
+    "saleBucket": "UNSCHEDULED"
+  },
+  {
+    "artist": "Red Velvet",
+    "entertainment": "SM Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=R9At2ICm4LQ",
+    "seatCount": 220,
+    "saleBucket": "OPEN_SOON_1H"
+  },
+  {
+    "artist": "OH MY GIRL",
+    "entertainment": "WM Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=HzOjwL7IP_o",
+    "seatCount": 190,
+    "saleBucket": "OPEN_SOON_1H"
+  },
+  {
+    "artist": "Apink",
+    "entertainment": "IST Entertainment",
+    "youtubeUrl": "https://www.youtube.com/watch?v=K5H-GvnNz2Y",
+    "seatCount": 180,
+    "saleBucket": "UNSCHEDULED"
+  }
+]

--- a/scripts/api/setup-kpop20-demo-data.sh
+++ b/scripts/api/setup-kpop20-demo-data.sh
@@ -12,6 +12,8 @@ JWT_SECRET="${JWT_SECRET:-ticketrush-local-dev-jwt-secret-key-change-this-value}
 PG_CONTAINER="${PG_CONTAINER:-ticket-core-service_postgres-db_1}"
 PG_USER="${PG_USER:-postgres}"
 PG_DB="${PG_DB:-mydb}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATASET_FILE="${DATASET_FILE:-${SCRIPT_DIR}/data/kpop20-demo-dataset.json}"
 
 if [[ -n "${RANDOM_SEED}" ]]; then
   RANDOM="${RANDOM_SEED}"
@@ -571,8 +573,7 @@ seed_single_concert() {
 
 main() {
   local admin_username admin_user_payload admin_user_response admin_user_id
-  local row index artist entertainment youtube seat_count sale_bucket dataset_total
-  local dataset_rows
+  local row_json index artist entertainment youtube seat_count sale_bucket dataset_total
 
   log "seed start api=${API_BASE} tag=${SEED_TAG}"
 
@@ -591,48 +592,46 @@ main() {
   ACCESS_TOKEN="$(build_access_token "${admin_user_id}" "${admin_username}" "ADMIN")"
   create_seed_users "${SEED_USER_COUNT}"
 
-  dataset_rows="$(cat <<'DATASET'
-Stray Kids|JYP Entertainment|https://www.youtube.com/watch?v=0P0aQreFs8w|260|OPEN_SOON_5M
-BTS|BIGHIT MUSIC|https://www.youtube.com/watch?v=gdZLi9oWNZg|320|OPEN
-Saja Boys|Netflix|https://www.youtube.com/watch?v=2FS3JAPTKXs|180|OPEN
-BLACKPINK|YG Entertainment|https://www.youtube.com/watch?v=IHNzOHi8sJs|300|OPEN
-NewJeans|ADOR|https://youtu.be/DAEK5GrLb_Y?si=rhJGnEY4sB0jay5s|260|OPEN_SOON_1H
-LE SSERAFIM|SOURCE MUSIC|https://youtu.be/hLvWy2b857I?si=aS73yFYIc0l53Cyo|240|OPEN_SOON_1H
-TOMORROW X TOGETHER|BIGHIT MUSIC|https://youtu.be/C0EYKxF1oTI?si=p6Wn2VSfC2R0jNPX|230|OPEN_SOON_1H
-ITZY|JYP Entertainment|https://www.youtube.com/watch?v=fE2h3lGlOsk|220|PREOPEN
-TWICE|JYP Entertainment|https://www.youtube.com/watch?v=i0p1bmr0EmE|280|PREOPEN
-SEVENTEEN|PLEDIS Entertainment|https://www.youtube.com/watch?v=-GQg25oP0S4|280|PREOPEN
-HUNTRIX|Sony Animation|https://www.youtube.com/watch?v=yebNIHKAC4A|170|SOLD_OUT
-BIGBANG|YG Entertainment|https://www.youtube.com/watch?v=2ips2mM7Zqw|220|SOLD_OUT
-BABYMONSTER|YG Entertainment|https://www.youtube.com/watch?v=2wA_b6YHjqQ|210|SOLD_OUT
-KARA|DSP Media|https://www.youtube.com/watch?v=XwcK-twSXB4|170|SOLD_OUT
-MAMAMOO|RBW|https://www.youtube.com/watch?v=KhTeiaCezwM|200|SOLD_OUT
-(G)I-DLE|CUBE Entertainment|https://www.youtube.com/watch?v=Jh4QFaPmdss|230|SOLD_OUT
-NMIXX|JYP Entertainment|https://www.youtube.com/watch?v=Rd2wppggYxo|200|SOLD_OUT
-aespa|SM Entertainment|https://www.youtube.com/watch?v=4TWR90KJl84|250|UNSCHEDULED
-IVE|STARSHIP Entertainment|https://www.youtube.com/watch?v=6ZUIwj3FgUY|240|OPEN_SOON_1H
-STAYC|High Up Entertainment|https://www.youtube.com/watch?v=SxHmoifp0oQ|190|OPEN_SOON_1H
-KISS OF LIFE|S2 Entertainment|https://www.youtube.com/watch?v=oKVYm8mIUdo|180|UNSCHEDULED
-Red Velvet|SM Entertainment|https://www.youtube.com/watch?v=R9At2ICm4LQ|220|OPEN_SOON_1H
-OH MY GIRL|WM Entertainment|https://www.youtube.com/watch?v=HzOjwL7IP_o|190|OPEN_SOON_1H
-Apink|IST Entertainment|https://www.youtube.com/watch?v=K5H-GvnNz2Y|180|UNSCHEDULED
-DATASET
-)"
-  dataset_total="$(printf '%s\n' "${dataset_rows}" | awk -F'|' 'NF >= 5 {count += 1} END {print count + 0}')"
+  if [[ ! -f "${DATASET_FILE}" ]]; then
+    echo "[ERROR] dataset file not found: ${DATASET_FILE}" >&2
+    exit 1
+  fi
+  if ! jq -e 'type == "array" and length > 0' "${DATASET_FILE}" >/dev/null; then
+    echo "[ERROR] dataset file must be a non-empty JSON array: ${DATASET_FILE}" >&2
+    exit 1
+  fi
+  if ! jq -e 'all(.[];
+      (.artist|type=="string" and length>0)
+      and (.entertainment|type=="string" and length>0)
+      and (.youtubeUrl|type=="string" and length>0)
+      and (.seatCount|type=="number")
+      and (.seatCount > 0)
+      and (.saleBucket|type=="string" and length>0)
+    )' "${DATASET_FILE}" >/dev/null; then
+    echo "[ERROR] dataset entries must include artist/entertainment/youtubeUrl/seatCount/saleBucket: ${DATASET_FILE}" >&2
+    exit 1
+  fi
+
+  dataset_total="$(jq 'length' "${DATASET_FILE}")"
   if [[ "${dataset_total}" == "0" ]]; then
     echo "[ERROR] dataset rows are empty" >&2
     exit 1
   fi
 
   index=0
-  while IFS='|' read -r artist entertainment youtube seat_count sale_bucket; do
+  while IFS= read -r row_json; do
+    artist="$(printf '%s' "${row_json}" | jq -r '.artist')"
+    entertainment="$(printf '%s' "${row_json}" | jq -r '.entertainment')"
+    youtube="$(printf '%s' "${row_json}" | jq -r '.youtubeUrl')"
+    seat_count="$(printf '%s' "${row_json}" | jq -r '.seatCount')"
+    sale_bucket="$(printf '%s' "${row_json}" | jq -r '.saleBucket')"
     if [[ -z "${artist}" ]]; then
       continue
     fi
     index=$((index + 1))
     log "seeding ${index}/${dataset_total} artist=${artist} status=${sale_bucket}"
     seed_single_concert "${index}" "${artist}" "${entertainment}" "${youtube}" "${seat_count}" "${sale_bucket}"
-  done <<< "${dataset_rows}"
+  done < <(jq -c '.[]' "${DATASET_FILE}")
 
   log "seed completed. summary:"
   printf '%-6s %-22s %-13s %7s %7s %7s %10s\n' "ID" "ARTIST" "STATUS" "SEATS" "HOLD" "PAYING" "CONFIRMED"


### PR DESCRIPTION
## Summary
- externalize KPOP20 seed dataset from heredoc to JSON file
- make seed script load dataset from `DATASET_FILE` (default: `scripts/api/data/kpop20-demo-dataset.json`)
- add JSON schema guard for required fields (`artist`, `entertainment`, `youtubeUrl`, `seatCount`, `saleBucket`)
- keep runtime domain/application behavior unchanged (seed path only)

## Related
- issue: #59

## Verification
- `bash -n scripts/api/setup-kpop20-demo-data.sh`
- `jq -e 'all(.[]; ...required fields...)' scripts/api/data/kpop20-demo-dataset.json`
- `SEED_USER_COUNT=64 bash scripts/api/setup-kpop20-demo-data.sh`
